### PR TITLE
fix: dynamically grab script install location

### DIFF
--- a/packages/ts-migrate/bin/ts-migrate-full.sh
+++ b/packages/ts-migrate/bin/ts-migrate-full.sh
@@ -4,7 +4,8 @@ set -e
 
 frontend_folder=$1
 folder_name=`basename $1`
-cli="./node_modules/.bin/ts-migrate"
+CLI_DIR=$(dirname "$0")
+cli="$CLI_DIR/ts-migrate"
 step_i=1
 step_count=4
 tsc_path="./node_modules/.bin/tsc"


### PR DESCRIPTION
Closes #14 

This makes the assumption that the `ts-migrate` script and the `ts-migrate-full` script will be installed in the same directory. Under that condition, this change grabs the appropriate location and allows users to install ts-migrate globally (and use correctly) with:

```bash
yarn global add ts-migrate
```