### PR TITLE
fix(ts-migrate): fix running on a windows machine

### DIFF
--- a/packages/ts-migrate/bin/reignore.sh
+++ b/packages/ts-migrate/bin/reignore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 NODE_OPTIONS=--max_old_space_size=8192 ./node_modules/.bin/jest \
   --config frontend/ts-migrate/scripts/jest-config-reignore.js \

--- a/packages/ts-migrate/bin/ts-migrate-full.sh
+++ b/packages/ts-migrate/bin/ts-migrate-full.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
 frontend_folder=$1
 folder_name=`basename $1`
 CLI_DIR=$(dirname "$0")
-cli="$CLI_DIR/ts-migrate"
+cli="./node_modules/ts-migrate/build/cli.js"
 step_i=1
 step_count=4
 tsc_path="./node_modules/.bin/tsc"

--- a/packages/ts-migrate/commands/init.ts
+++ b/packages/ts-migrate/commands/init.ts
@@ -29,7 +29,7 @@ export default function init({ rootDir, isExtendedConfig = false }: InitParams) 
   if (isExtendedConfig) {
     fs.writeFileSync(configFile, defaultConfig);
   } else {
-    execSync('$(npm bin)/tsc --init', { cwd: rootDir });
+    execSync('npx tsc --init', { cwd: rootDir });
   }
 
   log.info(`Config file created at ${configFile}`);


### PR DESCRIPTION
This fixes #16.

How I tested this:

* `yarn pack` inside of `packages/ts-migrate`
* `yarn link` inside of `packages/ts-migrate`
* `npm i -D ../path/to/ts-migrate-v0.1.1.tgz` inside of a test project
* Ran `npx ts-migrate-full .` inside test project
* Was given the prompt

```shell
Welcome to TS Migrate! :D

This script will migrate a frontend folder to a compiling (or almost compiling) TS project.

It is recommended that you take the following steps before continuing...

1. Make sure you have a clean git slate.
   Run `git status` to make sure you have no local changes that may get lost.
   Check in or stash your changes, then re-run this script.

2. Check out a new branch for the migration.
   For example, `git checkout -b james--ts-migrate` if you're migrating several folders or
   `git checkout -b james--ts-migrate-.` if you're just migrating ..

3. Make sure you're on the latest, clean master.
   `git fetch origin master && git reset --hard origin/master`

4. Make sure you have the latest npm modules installed.
   `npm install` or `yarn install`

If you need help or have feedback, please file an issue on Github!

Continue? (y/N) y
Set a custom path for the typescript compiler. (It's an optional step. Skip if you don't need it. Default path is ./node_modules/.bin/tsc.): 
Your default tsc path is ./node_modules/.bin/tsc.

[Step 1 of 4] Initializing ts-config for the "."...
```

I do find it weird that it stops after `1 of 4`, but I got that on a `macOS` operating system as well (before this fix).