### PR TITLE
feature(ts-migrate-plugins): adds support for react forwardRef

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/react-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-props.ts
@@ -297,7 +297,7 @@ function getPropsParam(node: ReactSfcNode) {
     const forwardRefComponent = getReactForwardRefFuncExpression(node);
     const forwardRefArgument =
       forwardRefComponent && forwardRefComponent.arguments && forwardRefComponent.arguments[0];
-    const forwardRefProps: false | ts.ParameterDeclaration =
+    const forwardRefProps =
       forwardRefArgument &&
       ts.isFunctionLike(forwardRefArgument) &&
       forwardRefArgument.parameters[0];
@@ -311,7 +311,7 @@ function getPropsParam(node: ReactSfcNode) {
   return undefined;
 }
 
-function getReactForwardRefFuncExpression(node: ReactNode): false | ts.CallExpression {
+function getReactForwardRefFuncExpression(node: ReactNode) {
   return (
     !!ts.isVariableStatement(node) &&
     !!node.declarationList?.declarations[0]?.initializer &&

--- a/packages/ts-migrate-plugins/src/plugins/utils/react.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/react.ts
@@ -56,11 +56,11 @@ export function isReactForwardRefName(initializer: ts.CallExpression) {
   const { expression } = initializer;
 
   if (ts.isIdentifier(expression)) {
-    return /forwardRef/gi.test(expression.escapedText as string);
+    return /forwardRef/gi.test(expression.escapedText.toString());
   }
 
   if (ts.isPropertyAccessExpression(expression)) {
-    return /forwardRef/gi.test(expression.name?.escapedText as string);
+    return /forwardRef/gi.test(expression.name?.escapedText.toString());
   }
 
   return false;

--- a/packages/ts-migrate-plugins/src/plugins/utils/react.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/react.ts
@@ -40,14 +40,30 @@ export function isReactSfcFunctionDeclaration(
 }
 
 export function isReactSfcArrowFunction(variableStatement: ts.VariableStatement): boolean {
-  return (
-    variableStatement.declarationList.declarations.length === 1 &&
+  return variableStatement.declarationList.declarations.length === 1 &&
     ts.isIdentifier(variableStatement.declarationList.declarations[0].name) &&
     /^[A-Z]\w*$/.test(variableStatement.declarationList.declarations[0].name.text) &&
     variableStatement.declarationList.declarations[0].initializer != null &&
-    ts.isArrowFunction(variableStatement.declarationList.declarations[0].initializer) &&
-    variableStatement.declarationList.declarations[0].initializer.parameters.length <= 2
-  );
+    ts.isCallExpression(variableStatement.declarationList.declarations[0].initializer) &&
+    isReactForwardRefName(variableStatement.declarationList.declarations[0].initializer)
+    ? true
+    : variableStatement.declarationList.declarations[0].initializer != null &&
+        ts.isArrowFunction(variableStatement.declarationList.declarations[0].initializer) &&
+        variableStatement.declarationList.declarations[0].initializer.parameters.length <= 2;
+}
+
+export function isReactForwardRefName(initializer: ts.CallExpression) {
+  const { expression } = initializer;
+
+  if (ts.isIdentifier(expression)) {
+    return /forwardRef/gi.test(expression.escapedText as string);
+  }
+
+  if (ts.isPropertyAccessExpression(expression)) {
+    return /forwardRef/gi.test(expression.name?.escapedText as string);
+  }
+
+  return false;
 }
 
 export function getReactComponentHeritageType(


### PR DESCRIPTION
Fix for: https://github.com/airbnb/ts-migrate/issues/9

The changes continuously check throughout the program whether a component is a forwardRef one and if that is the case, replaces the `forwardRef(...)` to `forwardRef<any, Props>(...)`. Decided to go for any for the typing of ref, as the ref can be of multiple different types for different jsx elements.