### PR TITLE
Fix typo in comment example-plugin-ts: decladetion -> declaration

### DIFF
--- a/packages/ts-migrate-example/src/example-plugin-ts.ts
+++ b/packages/ts-migrate-example/src/example-plugin-ts.ts
@@ -11,7 +11,7 @@ const examplePluginTs: Plugin<Options> = {
     const updates: SourceTextUpdate[] = [];
     const printer = ts.createPrinter();
 
-    // get all function decladations from the source file
+    // get all function declarations from the source file
     const functionDeclarations = sourceFile.statements.filter(ts.isFunctionDeclaration);
 
     functionDeclarations.forEach((functionDeclaration) => {


### PR DESCRIPTION
Fixed typo in comment: `decladation` -> `declaration`