### PR TITLE
Fix destructured prop types

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/react-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-props.ts
@@ -30,10 +30,12 @@ const reactPropsPlugin: Plugin<Options> = {
     const updates: SourceTextUpdate[] = [];
     const getPropsTypeName = createPropsTypeNameGetter(sourceFile);
 
-    // Scan for prop type imports
     const propTypeIdentifiers: PropTypesIdentifierMap = {};
+
     for (const node of sourceFile.statements) {
-      if (ts.isImportDeclaration(node) && node.moduleSpecifier.getText() === '"prop-types"') {
+      // Scan for prop type imports and build a map
+      // Assumes import statements are higher up in the file than react components
+      if (ts.isImportDeclaration(node) && /prop-types/.test(node.moduleSpecifier.getText())) {
         const importBindings = node.importClause?.namedBindings;
         if (importBindings && ts.isNamedImports(importBindings)) {
           importBindings.elements.forEach((specifier) => {
@@ -45,9 +47,7 @@ const reactPropsPlugin: Plugin<Options> = {
           });
         }
       }
-    }
 
-    for (const node of sourceFile.statements) {
       if (isReactNode(node)) {
         const componentName = getComponentName(node);
         const propsTypeName = getPropsTypeName(componentName);

--- a/packages/ts-migrate-plugins/tests/src/react-props.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/react-props.test.ts
@@ -1114,4 +1114,39 @@ class Foo extends React.Component<Props> {
 export default Foo;
 `);
   });
+
+  it('Handles destructuring of prop-types', async () => {
+    const text = `import React from "react";
+import { oneOf, node, func as propTypeFn } from "prop-types";
+import SomeClass from "someclass";
+
+const Foo = ({ children, className }) => {
+  return <div className={className}>children</div>;
+};
+
+Foo.propTypes = {
+  children: node,
+  callback: propTypeFn,
+  someObject: SomeClass,
+};
+
+export default Foo;`;
+
+    const result = await reactPropsPlugin.run(mockPluginParams({ text, fileName: 'Foo.tsx' }));
+
+    expect(result).toBe(`import React from "react";
+import SomeClass from "someclass";
+
+type Props = {
+    children?: React.ReactNode;
+    callback?: (...args: any[]) => any;
+    someObject?: SomeClass;
+};
+
+const Foo = ({ children, className }: Props) => {
+  return <div className={className}>children</div>;
+};
+
+export default Foo;`);
+  });
 });


### PR DESCRIPTION
Fixes the case where we use `import { string } from "prop-types"` instead of `import PropTypes from "prop-types"`

Fixes #24 