### PR TITLE
Handle diagnostic code 2551 in declare-missing-class-properties

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts
+++ b/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts
@@ -11,7 +11,7 @@ const declareMissingClassPropertiesPlugin: Plugin<Options> = {
   async run({ text, getDiagnostics, options }) {
     const diagnostics = (await getDiagnostics()).semanticDiagnostics
       .filter(isDiagnosticWithLinePosition)
-      .filter((diagnostic) => diagnostic.code === 2339);
+      .filter((diagnostic) => diagnostic.code === 2339 || diagnostic.code === 2551);
 
     const root = j(text);
 

--- a/packages/ts-migrate-plugins/tests/src/declare-missing-class-properties.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/declare-missing-class-properties.test.ts
@@ -2,8 +2,10 @@ import { mockDiagnostic, mockPluginParams } from '../test-utils';
 import declareMissingClassPropertiesPlugin from '../../src/plugins/declare-missing-class-properties';
 
 describe('declare-missing-class-properties plugin', () => {
-  it('declares missing class properties', async () => {
-    const text = `class Class1 {
+  it.each([2339, 2551])(
+    'declares missing class properties with diagnostic code %i',
+    async (diagnosticCode) => {
+      const text = `class Class1 {
   static foo = 123;
   method1() {
     console.log(this.property1a);
@@ -24,21 +26,21 @@ class Class2 {
   }
 }`;
 
-    const diagnosticFor = (str: string) => mockDiagnostic(text, str, { code: 2339 });
-    const result = await declareMissingClassPropertiesPlugin.run(
-      mockPluginParams({
-        options: { anyAlias: '$TSFixMe' },
-        text,
-        semanticDiagnostics: [
-          diagnosticFor('property1a'),
-          diagnosticFor('property2a'),
-          diagnosticFor('property1b'),
-          diagnosticFor('property2b'),
-        ],
-      }),
-    );
+      const diagnosticFor = (str: string) => mockDiagnostic(text, str, { code: diagnosticCode });
+      const result = await declareMissingClassPropertiesPlugin.run(
+        mockPluginParams({
+          options: { anyAlias: '$TSFixMe' },
+          text,
+          semanticDiagnostics: [
+            diagnosticFor('property1a'),
+            diagnosticFor('property2a'),
+            diagnosticFor('property1b'),
+            diagnosticFor('property2b'),
+          ],
+        }),
+      );
 
-    expect(result).toBe(`class Class1 {
+      expect(result).toBe(`class Class1 {
   static foo = 123;
   property1a: $TSFixMe;
   property2a: $TSFixMe;
@@ -62,5 +64,6 @@ class Class2 {
     console.log(this.property2b);
   }
 }`);
-  });
+    },
+  );
 });


### PR DESCRIPTION
Diagnostic code 2551 is similar to 2339, but occurs when there are two class members with similar names, and so it suggests that you might have intended the other one.

It is effectively the same as 2339 from ts-migrate's point of view.

See the diagnostic message [here](https://github.com/microsoft/TypeScript/blob/v4.0.2/src/compiler/diagnosticMessages.json#L2373-L2376).

I have run this rule over a large internal project that had missed some class field declarations, and with this change it's picked them up.