### PR TITLE
JSDoc plugin

### DIFF
--- a/packages/ts-migrate-plugins/src/index.ts
+++ b/packages/ts-migrate-plugins/src/index.ts
@@ -3,6 +3,7 @@ import declareMissingClassPropertiesPlugin from './plugins/declare-missing-class
 import eslintFixPlugin from './plugins/eslint-fix';
 import explicitAnyPlugin from './plugins/explicit-any';
 import hoistClassStaticsPlugin from './plugins/hoist-class-statics';
+import jsDocPlugin from './plugins/jsdoc';
 import reactClassLifecycleMethodsPlugin from './plugins/react-class-lifecycle-methods';
 import reactClassStatePlugin from './plugins/react-class-state';
 import reactDefaultPropsPlugin from './plugins/react-default-props';
@@ -22,6 +23,7 @@ export {
   eslintFixPlugin,
   explicitAnyPlugin,
   hoistClassStaticsPlugin,
+  jsDocPlugin,
   reactClassLifecycleMethodsPlugin,
   reactClassStatePlugin,
   reactDefaultPropsPlugin,

--- a/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
+++ b/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
@@ -104,7 +104,7 @@ const jsDocTransformerFactory = ({
     }
 
     // create a new function declaration with a new type
-    return functionDeclaration.parameters.map((param) => {
+    const newParams = functionDeclaration.parameters.map((param) => {
       if (param.type) {
         // Don't overwrite existing annotations.
         return param;
@@ -136,6 +136,11 @@ const jsDocTransformerFactory = ({
 
       return newParam;
     });
+    if (functionDeclaration.parameters.some((param, i) => param !== newParams[i])) {
+      // Only return the new array if something changed.
+      return newParams;
+    }
+    return functionDeclaration.parameters;
   }
 
   function visitReturnType(functionDeclaration: ts.SignatureDeclaration): ts.TypeNode | undefined {

--- a/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
+++ b/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
@@ -118,7 +118,9 @@ const jsDocTransformerFactory = ({
       const type = visitJSDocType(typeNode, true);
 
       const questionToken =
-        ts.isIdentifier(param.name) && (paramNode.isBracketed || ts.isJSDocOptionalType(typeNode))
+        !param.initializer &&
+        ts.isIdentifier(param.name) &&
+        (paramNode.isBracketed || ts.isJSDocOptionalType(typeNode))
           ? ts.createToken(ts.SyntaxKind.QuestionToken)
           : param.questionToken;
 

--- a/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
+++ b/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
@@ -1,0 +1,360 @@
+/* eslint-disable no-bitwise */
+import ts from 'typescript';
+import { Plugin } from 'ts-migrate-server';
+
+type TypeMap = Record<string, TypeOptions>;
+
+type TypeOptions =
+  | string
+  | {
+      tsName?: string;
+      acceptsTypeParameters?: boolean;
+    };
+
+const defaultTypeMap: TypeMap = {
+  String: {
+    tsName: 'string',
+    acceptsTypeParameters: false,
+  },
+  Boolean: {
+    tsName: 'boolean',
+    acceptsTypeParameters: false,
+  },
+  Number: {
+    tsName: 'number',
+    acceptsTypeParameters: false,
+  },
+  Object: {
+    tsName: 'object',
+    // Object<string, T> and Object<number, T> are handled as a special case.
+    acceptsTypeParameters: false,
+  },
+  date: {
+    tsName: 'Date',
+    acceptsTypeParameters: false,
+  },
+  array: 'Array',
+  promise: 'Promise',
+};
+
+type Options = {
+  annotateReturns?: boolean;
+  anyAlias?: string;
+  typeMap?: TypeMap;
+};
+
+const jsDocPlugin: Plugin<Options> = {
+  name: 'jsdoc',
+  run({ sourceFile, text, options }) {
+    const result = ts.transform<ts.SourceFile>(sourceFile, [jsDocTransformerFactory(options)]);
+    const newSourceFile = result.transformed[0];
+    if (newSourceFile === sourceFile) {
+      return text;
+    }
+    const printer = ts.createPrinter();
+    return printer.printFile(newSourceFile);
+  },
+};
+
+export default jsDocPlugin;
+
+const jsDocTransformerFactory = ({
+  annotateReturns,
+  anyAlias,
+  typeMap: optionsTypeMap,
+}: Options) => (context: ts.TransformationContext) => {
+  const anyType = anyAlias
+    ? ts.createTypeReferenceNode(anyAlias, undefined)
+    : ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+  const typeMap: TypeMap = { ...defaultTypeMap, ...optionsTypeMap };
+
+  function visit<T extends ts.Node>(origNode: T): T {
+    const node = ts.visitEachChild(origNode, visit, context);
+    if (ts.isFunctionLike(node)) {
+      return visitFunctionLike(node, ts.isClassDeclaration(origNode.parent)) as T;
+    }
+    return node;
+  }
+
+  function visitFunctionLike<T extends ts.SignatureDeclaration>(node: T, insideClass: boolean): T {
+    const modifiers =
+      ts.isMethodDeclaration(node) && insideClass ? modifiersFromJSDoc(node) : node.modifiers;
+    const parameters = visitParameters(node);
+    const returnType = annotateReturns ? visitReturnType(node) : node.type;
+    if (
+      modifiers === node.modifiers &&
+      parameters === node.parameters &&
+      returnType === node.type
+    ) {
+      return node;
+    }
+
+    const newNode = ts.getMutableClone(node);
+    newNode.modifiers = ts.createNodeArray(modifiers);
+    newNode.parameters = ts.createNodeArray(parameters);
+    newNode.type = returnType;
+    return newNode;
+  }
+
+  function visitParameters(
+    functionDeclaration: ts.SignatureDeclaration,
+  ): ReadonlyArray<ts.ParameterDeclaration> {
+    if (!ts.hasJSDocParameterTags(functionDeclaration)) {
+      return functionDeclaration.parameters;
+    }
+
+    // create a new function declaration with a new type
+    return functionDeclaration.parameters.map((param) => {
+      if (param.type) {
+        // Don't overwrite existing annotations.
+        return param;
+      }
+
+      const paramNode = ts.getJSDocParameterTags(param).find((tag) => tag.typeExpression);
+      if (!paramNode || !paramNode.typeExpression) {
+        return param;
+      }
+      const typeNode = paramNode.typeExpression.type;
+      const type = visitJSDocType(typeNode, true);
+
+      const questionToken =
+        ts.isIdentifier(param.name) && (paramNode.isBracketed || ts.isJSDocOptionalType(typeNode))
+          ? ts.createToken(ts.SyntaxKind.QuestionToken)
+          : param.questionToken;
+
+      const newParam = ts.createParameter(
+        param.decorators,
+        param.modifiers,
+        param.dotDotDotToken,
+        param.name,
+        questionToken,
+        type,
+        param.initializer,
+      );
+
+      return newParam;
+    });
+  }
+
+  function visitReturnType(functionDeclaration: ts.SignatureDeclaration): ts.TypeNode | undefined {
+    if (functionDeclaration.type) {
+      // Don't overwrite existing annotations.
+      return functionDeclaration.type;
+    }
+    const returnTypeNode = ts.getJSDocReturnType(functionDeclaration);
+    if (!returnTypeNode) {
+      return functionDeclaration.type;
+    }
+    return visitJSDocType(returnTypeNode);
+  }
+
+  // All visitJSDoc functions are adapted from:
+  // https://github.com/microsoft/TypeScript/blob/v4.0.2/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+
+  function visitJSDocType(node: ts.Node, topLevelParam = false): ts.TypeNode {
+    switch (node.kind) {
+      case ts.SyntaxKind.JSDocAllType:
+      case ts.SyntaxKind.JSDocUnknownType:
+        return anyType;
+      case ts.SyntaxKind.JSDocOptionalType:
+        if (topLevelParam) {
+          // Ignore the optionality.
+          // We'll make the entire parameter optional inside visitParameters
+          return visitJSDocType((node as ts.JSDocOptionalType).type);
+        }
+        return visitJSDocOptionalType(node as ts.JSDocOptionalType);
+
+      case ts.SyntaxKind.JSDocNonNullableType:
+        return visitJSDocType((node as ts.JSDocNonNullableType).type);
+      case ts.SyntaxKind.JSDocNullableType:
+        return visitJSDocNullableType(node as ts.JSDocNullableType);
+      case ts.SyntaxKind.JSDocVariadicType:
+        return visitJSDocVariadicType(node as ts.JSDocVariadicType);
+      case ts.SyntaxKind.JSDocFunctionType:
+        return visitJSDocFunctionType(node as ts.JSDocFunctionType);
+      case ts.SyntaxKind.JSDocTypeLiteral:
+        return visitJSDocTypeLiteral(node as ts.JSDocTypeLiteral);
+      case ts.SyntaxKind.TypeReference:
+        return visitJSDocTypeReference(node as ts.TypeReferenceNode);
+      default: {
+        const visited = ts.visitEachChild(node, visitJSDocType, context);
+        ts.setEmitFlags(visited, ts.EmitFlags.SingleLine);
+        return visited as ts.TypeNode;
+      }
+    }
+  }
+
+  function visitJSDocOptionalType(node: ts.JSDocOptionalType) {
+    return ts.createUnionTypeNode([
+      ts.visitNode(node.type, visitJSDocType),
+      ts.createKeywordTypeNode(ts.SyntaxKind.UndefinedKeyword),
+    ]);
+  }
+
+  function visitJSDocNullableType(node: ts.JSDocNullableType) {
+    return ts.createUnionTypeNode([
+      ts.visitNode(node.type, visitJSDocType),
+      ts.createKeywordTypeNode(ts.SyntaxKind.NullKeyword),
+    ]);
+  }
+
+  function visitJSDocVariadicType(node: ts.JSDocVariadicType) {
+    return ts.createArrayTypeNode(ts.visitNode(node.type, visitJSDocType));
+  }
+
+  function visitJSDocFunctionType(node: ts.JSDocFunctionType) {
+    return ts.createFunctionTypeNode(
+      undefined,
+      node.parameters.map(visitJSDocParameter),
+      node.type ?? anyType,
+    );
+  }
+
+  function visitJSDocTypeLiteral(node: ts.JSDocTypeLiteral) {
+    const propertySignatures: ts.PropertySignature[] = [];
+    if (node.jsDocPropertyTags) {
+      node.jsDocPropertyTags.forEach((tag) => {
+        const property = visitJSDocPropertyLikeTag(tag);
+        if (property) {
+          propertySignatures.push(property);
+        }
+      });
+    }
+    return ts.createTypeLiteralNode(propertySignatures);
+  }
+
+  function visitJSDocPropertyLikeTag(node: ts.JSDocPropertyLikeTag) {
+    let optionalType = false;
+    let type;
+    if (node.typeExpression) {
+      type = visitJSDocType(node.typeExpression.type);
+      optionalType = ts.isJSDocOptionalType(node.typeExpression);
+    } else {
+      type = anyType;
+    }
+    const questionToken =
+      node.isBracketed || optionalType ? ts.createToken(ts.SyntaxKind.QuestionToken) : undefined;
+    if (ts.isIdentifier(node.name)) {
+      return ts.createPropertySignature(undefined, node.name, questionToken, type, undefined);
+    }
+    // Assumption: the leaf field on the QualifiedName belongs directly to the parent object type.
+    return ts.createPropertySignature(undefined, node.name.right, questionToken, type, undefined);
+  }
+
+  function visitJSDocParameter(node: ts.ParameterDeclaration) {
+    const index = node.parent.parameters.indexOf(node);
+    const isRest =
+      node.type!.kind === ts.SyntaxKind.JSDocVariadicType &&
+      index === node.parent.parameters.length - 1;
+    const name = node.name || (isRest ? 'rest' : `arg${index}`);
+    const dotdotdot = isRest ? ts.createToken(ts.SyntaxKind.DotDotDotToken) : node.dotDotDotToken;
+    return ts.createParameter(
+      node.decorators,
+      node.modifiers,
+      dotdotdot,
+      name,
+      node.questionToken,
+      ts.visitNode(node.type, visitJSDocType),
+      node.initializer,
+    );
+  }
+
+  function visitJSDocTypeReference(node: ts.TypeReferenceNode) {
+    let name = node.typeName;
+    let args = node.typeArguments;
+    if (ts.isIdentifier(node.typeName)) {
+      if (isJSDocIndexSignature(node)) {
+        return visitJSDocIndexSignature(node);
+      }
+      let { text } = node.typeName;
+      let acceptsTypeParameters = true;
+      if (text in typeMap) {
+        const typeOptions = typeMap[text];
+        if (typeof typeOptions === 'string') {
+          text = typeOptions;
+        } else {
+          if (typeOptions.tsName) {
+            text = typeOptions.tsName;
+          }
+          acceptsTypeParameters = typeOptions.acceptsTypeParameters !== false;
+        }
+      }
+
+      name = ts.createIdentifier(text);
+      if ((text === 'Array' || text === 'Promise') && !node.typeArguments) {
+        args = ts.createNodeArray([anyType]);
+      } else if (acceptsTypeParameters) {
+        args = ts.visitNodes(node.typeArguments, visitJSDocType);
+      }
+      if (!acceptsTypeParameters) {
+        args = undefined;
+      }
+    }
+    return ts.createTypeReferenceNode(name, args);
+  }
+
+  function visitJSDocIndexSignature(node: ts.TypeReferenceNode) {
+    const index = ts.createParameter(
+      /* decorators */ undefined,
+      /* modifiers */ undefined,
+      /* dotDotDotToken */ undefined,
+      node.typeArguments![0].kind === ts.SyntaxKind.NumberKeyword ? 'n' : 's',
+      /* questionToken */ undefined,
+      ts.createTypeReferenceNode(
+        node.typeArguments![0].kind === ts.SyntaxKind.NumberKeyword ? 'number' : 'string',
+        [],
+      ),
+      /* initializer */ undefined,
+    );
+    const indexSignature = ts.createTypeLiteralNode([
+      ts.createIndexSignature(
+        /* decorators */ undefined,
+        /* modifiers */ undefined,
+        [index],
+        node.typeArguments![1],
+      ),
+    ]);
+    ts.setEmitFlags(indexSignature, ts.EmitFlags.SingleLine);
+    return indexSignature;
+  }
+
+  return visit;
+};
+
+const accessibilityMask =
+  ts.ModifierFlags.Private | ts.ModifierFlags.Protected | ts.ModifierFlags.Public;
+
+function modifiersFromJSDoc(
+  methodDeclaration: ts.MethodDeclaration,
+): ReadonlyArray<ts.Modifier> | undefined {
+  let modifierFlags = ts.getCombinedModifierFlags(methodDeclaration);
+  if ((modifierFlags & accessibilityMask) !== 0) {
+    // Don't overwrite existing accessibility modifier.
+    return methodDeclaration.modifiers;
+  }
+
+  if (ts.getJSDocPrivateTag(methodDeclaration)) {
+    modifierFlags |= ts.ModifierFlags.Private;
+  } else if (ts.getJSDocProtectedTag(methodDeclaration)) {
+    modifierFlags |= ts.ModifierFlags.Protected;
+  } else if (ts.getJSDocPublicTag(methodDeclaration)) {
+    modifierFlags |= ts.ModifierFlags.Public;
+  } else {
+    return methodDeclaration.modifiers;
+  }
+
+  return ts.createModifiersFromModifierFlags(modifierFlags);
+}
+
+// Copied from: https://github.com/microsoft/TypeScript/blob/v4.0.2/src/compiler/utilities.ts#L1879
+function isJSDocIndexSignature(node: ts.TypeReferenceNode | ts.ExpressionWithTypeArguments) {
+  return (
+    ts.isTypeReferenceNode(node) &&
+    ts.isIdentifier(node.typeName) &&
+    node.typeName.escapedText === 'Object' &&
+    node.typeArguments &&
+    node.typeArguments.length === 2 &&
+    (node.typeArguments[0].kind === ts.SyntaxKind.StringKeyword ||
+      node.typeArguments[0].kind === ts.SyntaxKind.NumberKeyword)
+  );
+}

--- a/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
@@ -1,0 +1,513 @@
+import { mockPluginParams } from '../test-utils';
+import jsDocPlugin from '../../src/plugins/jsdoc';
+
+describe('jsdoc plugin', () => {
+  it('annotates unknown types', () => {
+    const text = `\
+/** @param a {?} */
+function A(a) {}
+/** @param b {*} */
+function B(b) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {?} */
+function A(a: any) { }
+/** @param b {*} */
+function B(b: any) { }
+`);
+  });
+
+  it('considers synonym tags', () => {
+    const text = `\
+/** @arg a {Number} */
+function A(a) {}
+/** @argument b {Number} */
+function B(b) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @arg a {Number} */
+function A(a: number) { }
+/** @argument b {Number} */
+function B(b: number) { }
+`);
+  });
+
+  it('annotates simple type references', () => {
+    const text = `\
+/** @param a {Number} */
+function A(a) {}
+/** @param b {String} */
+function B(b) {}
+/** @param c {Boolean} */
+function C(c) {}
+/** @param d {Object} */
+function D(d) {}
+/** @param e {date} */
+function E(e) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {Number} */
+function A(a: number) { }
+/** @param b {String} */
+function B(b: string) { }
+/** @param c {Boolean} */
+function C(c: boolean) { }
+/** @param d {Object} */
+function D(d: object) { }
+/** @param e {date} */
+function E(e: Date) { }
+`);
+  });
+
+  it('ignores nonsensical type parameters', () => {
+    const text = `\
+/** @param a {Number<string>} */
+function A(a) {}
+/** @param b {String<string>} */
+function B(b) {}
+/** @param c {Boolean<string>} */
+function C(c) {}
+/** @param d {Object<object>} */
+function D(d) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {Number<string>} */
+function A(a: number) { }
+/** @param b {String<string>} */
+function B(b: string) { }
+/** @param c {Boolean<string>} */
+function C(c: boolean) { }
+/** @param d {Object<object>} */
+function D(d: object) { }
+`);
+  });
+
+  it('annotates nullable types', () => {
+    const text = `\
+/** @param a {?Number} */
+function A(a) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {?Number} */
+function A(a: number | null) { }
+`);
+  });
+
+  it('annotates non-nullable types', () => {
+    const text = `\
+/** @param a {!Number} */
+function A(a) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {!Number} */
+function A(a: number) { }
+`);
+  });
+
+  it('annotates optional types', () => {
+    const text = `\
+/** @param a {Number=} */
+function A(a) {}
+/** @param [b] {Number} */
+function B(b) {}
+/** @param [c] {Object} */
+function C({ c }) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {Number=} */
+function A(a?: number) { }
+/** @param [b] {Number} */
+function B(b?: number) { }
+/** @param [c] {Object} */
+function C({ c }: object) { }
+`);
+  });
+
+  it('annotates parameterized types', () => {
+    const text = `\
+/** @param a {Array} */
+function A(a) {}
+/** @param b {Array<String>} */
+function B(b) {}
+/** @param c {Array.<String>} */
+function C(c) {}
+/** @param d {String[]} */
+function D(d) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {Array} */
+function A(a: Array<any>) { }
+/** @param b {Array<String>} */
+function B(b: Array<string>) { }
+/** @param c {Array.<String>} */
+function C(c: Array<string>) { }
+/** @param d {String[]} */
+function D(d: string[]) { }
+`);
+  });
+
+  it('annotates object index types', () => {
+    const text = `\
+/** @param a {Object<number, any>} */
+function A(a) {}
+/** @param b {Object<string, any>} */
+function B(b) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {Object<number, any>} */
+function A(a: { [n: number]: any; }) { }
+/** @param b {Object<string, any>} */
+function B(b: { [s: string]: any; }) { }
+`);
+  });
+
+  it('annotates documented properties', () => {
+    const text = `\
+/**
+ * @param {Object} employee
+ * @param {string} employee.name
+ * @param {string} [employee.department]
+ */
+function Project(employee) {}
+/**
+ * @param {Object} employee
+ * @param employee.name
+ * @param employee.department
+ */
+function NoTypes(employee) {}
+/**
+ * @param {Object} employee
+ * @param {Object} employee.name
+ * @param {string} employee.name.first
+ */
+function DeepNesting(employee) {}
+/**
+ * @param {Object} param
+ * @param {String} param.a
+ * @param {Number} param.b
+ */
+function Destructured({ a, b }) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/**
+ * @param {Object} employee
+ * @param {string} employee.name
+ * @param {string} [employee.department]
+ */
+function Project(employee: {
+    name: string;
+    department?: string;
+}) { }
+/**
+ * @param {Object} employee
+ * @param employee.name
+ * @param employee.department
+ */
+function NoTypes(employee: {
+    name: any;
+    department: any;
+}) { }
+/**
+ * @param {Object} employee
+ * @param {Object} employee.name
+ * @param {string} employee.name.first
+ */
+function DeepNesting(employee: {
+    name: {
+        first: string;
+    };
+}) { }
+/**
+ * @param {Object} param
+ * @param {String} param.a
+ * @param {Number} param.b
+ */
+function Destructured({ a, b }: {
+    a: string;
+    b: number;
+}) { }
+`);
+  });
+
+  it('annotates undeclared types', () => {
+    const text = `\
+/** @param a {Undeclared} */
+function A(a) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {Undeclared} */
+function A(a: Undeclared) { }
+`);
+  });
+
+  it('annotates partially-documented functions', () => {
+    const text = `\
+/**
+ * @param a {number}
+ * @param b {string}
+ */
+function A(a, b, c) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/**
+ * @param a {number}
+ * @param b {string}
+ */
+function A(a: number, b: string, c) { }
+`);
+  });
+
+  it('handles misdocumented parameters', () => {
+    const text = `\
+/** @param b {number} */
+function A(a) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param b {number} */
+function A(a) { }
+`);
+  });
+
+  it('annotates return type', () => {
+    const text = `\
+/** @return {number} */
+function A() {}
+`;
+
+    const result = jsDocPlugin.run(
+      mockPluginParams({ text, fileName: 'file.tsx', options: { annotateReturns: true } }),
+    );
+
+    expect(result).toBe(`\
+/** @return {number} */
+function A(): number { }
+`);
+  });
+
+  it('does not overwrite existing annotations', () => {
+    const text = `\
+/** @param a {number} */
+function A(a: string) {}
+/** @return {number} */
+function B(): string {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {number} */
+function A(a: string) { }
+/** @return {number} */
+function B(): string { }
+`);
+  });
+
+  it('annotates class methods', () => {
+    const text = `\
+class C {
+  /** @param a {number} */
+  A(a) {}
+}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+class C {
+    /** @param a {number} */
+    A(a: number) { }
+}
+`);
+  });
+
+  it('adds accessibility modifiers to class methods', () => {
+    const text = `\
+class C {
+  /** @private */
+  A() {}
+  /** @protected */
+  B() {}
+  /** @public */
+  C() {}
+  /**
+   * @private
+   * @protected
+   * @public
+   */
+  D() {}
+  /** @public */
+  private E() {}
+}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+class C {
+    /** @private */
+    private A() { }
+    /** @protected */
+    protected B() { }
+    /** @public */
+    public C() { }
+    /**
+     * @private
+     * @protected
+     * @public
+     */
+    private D() { }
+    /** @public */
+    private E() { }
+}
+`);
+  });
+
+  it('annotates object literal methods', () => {
+    const text = `\
+const O = {
+  /** @param a {number} */
+  A(a) {},
+  /** @return {string} */
+  B() {},
+  /** @private */
+  C() {},
+  /** @param a {number} */
+  D: (a) => {},
+  /** @return {string} */
+  E: () => {}
+};
+`;
+
+    const result = jsDocPlugin.run(
+      mockPluginParams({ text, fileName: 'file.tsx', options: { annotateReturns: true } }),
+    );
+
+    expect(result).toBe(`\
+const O = {
+    /** @param a {number} */
+    A(a: number) { },
+    /** @return {string} */
+    B(): string { },
+    /** @private */
+    C() { },
+    /** @param a {number} */
+    D: (a: number) => { },
+    /** @return {string} */
+    E: (): string => { }
+};
+`);
+  });
+
+  it('annotates function expressions', () => {
+    const text = `\
+/** @param a {number} */
+const A = function(a) {};
+/** @return {string} */
+const B = function() {};
+/** @param c {number} */
+window.c = function(c) {};
+`;
+
+    const result = jsDocPlugin.run(
+      mockPluginParams({ text, fileName: 'file.tsx', options: { annotateReturns: true } }),
+    );
+
+    expect(result).toBe(`\
+/** @param a {number} */
+const A = function (a: number) { };
+/** @return {string} */
+const B = function (): string { };
+/** @param c {number} */
+window.c = function (c: number) { };
+`);
+  });
+
+  it('annotates arrow functions', () => {
+    const text = `\
+/** @param a {number} */
+const A = (a) => null;
+/** @return {string} */
+const B = (b) => null;
+/** @param c {number} */
+const C = c => null;
+/** @return {string} */
+const D = d => null;
+/** @param e {number} */
+window.e = (e) => null;
+`;
+
+    const result = jsDocPlugin.run(
+      mockPluginParams({ text, fileName: 'file.tsx', options: { annotateReturns: true } }),
+    );
+
+    expect(result).toBe(`\
+/** @param a {number} */
+const A = (a: number) => null;
+/** @return {string} */
+const B = (b): string => null;
+/** @param c {number} */
+const C = (c: number) => null;
+/** @return {string} */
+const D = (d): string => null;
+/** @param e {number} */
+window.e = (e: number) => null;
+`);
+  });
+
+  it('annotates functions that are not at the top level', () => {
+    const text = `\
+function() {
+    /** @param a {number} */
+    function A(a) {}
+}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+function () {
+    /** @param a {number} */
+    function A(a: number) { }
+}
+`);
+  });
+});

--- a/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
@@ -130,6 +130,8 @@ function A(a) {}
 function B(b) {}
 /** @param [c] {Object} */
 function C({ c }) {}
+/** @param [d] {Number} */
+function D(d = 1) {}
 `;
 
     const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
@@ -141,6 +143,8 @@ function A(a?: number) { }
 function B(b?: number) { }
 /** @param [c] {Object} */
 function C({ c }: object) { }
+/** @param [d] {Number} */
+function D(d: number = 1) { }
 `);
   });
 

--- a/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
@@ -192,6 +192,32 @@ function B(b: { [s: string]: any; }) { }
 `);
   });
 
+  it('annotates function types', () => {
+    const text = `\
+/** @param a {function(number)} */
+function A(a) {}
+/** @param b {function(): number} */
+function B(b) {}
+/** @param c {function(this: number)} */
+function C(c) {}
+/** @param d {function(...number)} */
+function D(d) {}
+`;
+
+    const result = jsDocPlugin.run(mockPluginParams({ text, fileName: 'file.tsx' }));
+
+    expect(result).toBe(`\
+/** @param a {function(number)} */
+function A(a: (arg0: number) => any) { }
+/** @param b {function(): number} */
+function B(b: () => number) { }
+/** @param c {function(this: number)} */
+function C(c: (this: number) => any) { }
+/** @param d {function(...number)} */
+function D(d: (...rest: number[]) => any) { }
+`);
+  });
+
   it('annotates documented properties', () => {
     const text = `\
 /**

--- a/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/jsdoc.test.ts
@@ -307,7 +307,7 @@ function A(a) {}
 
     expect(result).toBe(`\
 /** @param b {number} */
-function A(a) { }
+function A(a) {}
 `);
   });
 
@@ -339,9 +339,9 @@ function B(): string {}
 
     expect(result).toBe(`\
 /** @param a {number} */
-function A(a: string) { }
+function A(a: string) {}
 /** @return {number} */
-function B(): string { }
+function B(): string {}
 `);
   });
 

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -86,16 +86,13 @@ yargs
           process.exit(1);
           return;
         }
-        const options: any = {};
         if (plugin === jsDocPlugin) {
-          if (typeof args.typeMap === 'string') {
-            options.typeMap = JSON.parse(args.typeMap);
-          }
-          if (args.aliases === 'tsfixme') {
-            options.anyAlias = '$TSFixMe';
-          }
+          const anyAlias = args.aliases === 'tsfixme' ? '$TSFixMe' : undefined;
+          const typeMap = typeof args.typeMap === 'string' ? JSON.parse(args.typeMap) : undefined;
+          config = new MigrateConfig().addPlugin(jsDocPlugin, { anyAlias, typeMap });
+        } else {
+          config = new MigrateConfig().addPlugin(plugin, {});
         }
-        config = new MigrateConfig().addPlugin(plugin, options);
       } else {
         const airbnbAnyAlias = '$TSFixMe';
         const airbnbAnyFunctionAlias = '$TSFixMeFunction';

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -10,6 +10,7 @@ import {
   eslintFixPlugin,
   explicitAnyPlugin,
   hoistClassStaticsPlugin,
+  jsDocPlugin,
   reactClassLifecycleMethodsPlugin,
   reactClassStatePlugin,
   reactDefaultPropsPlugin,
@@ -70,6 +71,7 @@ yargs
           eslintFixPlugin,
           explicitAnyPlugin,
           hoistClassStaticsPlugin,
+          jsDocPlugin,
           reactClassLifecycleMethodsPlugin,
           reactClassStatePlugin,
           reactDefaultPropsPlugin,
@@ -84,7 +86,16 @@ yargs
           process.exit(1);
           return;
         }
-        config = new MigrateConfig().addPlugin(plugin, {});
+        const options: any = {};
+        if (plugin === jsDocPlugin) {
+          if (typeof args.typeMap === 'string') {
+            options.typeMap = JSON.parse(args.typeMap);
+          }
+          if (args.aliases === 'tsfixme') {
+            options.anyAlias = '$TSFixMe';
+          }
+        }
+        config = new MigrateConfig().addPlugin(plugin, options);
       } else {
         const airbnbAnyAlias = '$TSFixMe';
         const airbnbAnyFunctionAlias = '$TSFixMeFunction';


### PR DESCRIPTION
This plugin converts JSDoc type annotations to TypeScript annotations. It can also convert tags such as `@private` to TypeScript accessibility modifiers. It only works on function-like constructs for the moment.

I've run this over a fairly large internal codebase and am happy with the results I've gotten.

## Configuration
The `annotateReturns` option -- off by default -- chooses whether or not to add annotations to function return types. Often return types can be inferred and I found that using the types from JSDoc comments can make things worse rather than better!

The `typeMap` option allows clients to specify mappings from JSDoc names to TypeScript type names. For example, in our AngularJS code we would often document a parameter as `Promise` when it should have really been `IPromise` from AngularJS.

It also allows the conventional `anyAlias` option.

## Implementation
This plugin uses `ts.transform`, which I haven't seen other plugins use, but I chose this because JSDoc comments may appear at any level -- not just the top level. jscodeshift does not seem to have good support for JSDoc.

Much of the code is adapted from [the `annotateWithTypeFromJSDoc` codefix](https://github.com/microsoft/TypeScript/blob/v4.0.2/src/services/codefixes/annotateWithTypeFromJSDoc.ts).

## Limitations
The plugin still emits TypeScript type annotations for types that haven't been declared. For example:

```ts
/** @param p {Undeclared} */
function F(p) {}
```

results in:

```ts
/** @param p {Undeclared} */
function F(p: Undeclared) {}
```

This can be fixed up by a pass of the `ts-ignore` plugin, so I don't consider it much of a problem.

It's likely there are other limitations that I haven't encountered yet, but I'd be happy to receive feedback if anybody runs into them in their codebase.

## Running

The CLI does not run this plugin by default with the `migrate` command, but it may be used with the `--plugin` flag.

It accepts `--type-map` and `--alias` flags. An example invocation looks like:

```
npx ts-migrate -- migrate --plugin jsdoc --alias tsfixme --type-map '{"Promise": "IPromise", "Function": "$TSFixMeFunction"}' frontend/foo
```

Closes #20.