### PR TITLE
Member accessibility plugin

### DIFF
--- a/packages/ts-migrate-plugins/README.md
+++ b/packages/ts-migrate-plugins/README.md
@@ -52,6 +52,8 @@ process.exit(exitCode);
 | [eslint-fix](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/eslint-fix.ts) | Run eslint fix to fix any eslint violations that happened along the way. |
 | [explicit-any](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/explicit-any.ts) | Annotate variables with `any` (`$TSFixMe`) in the case of an implicit any violation. |
 | [hoist-class-statics](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/hoist-class-statics.ts) | Hoist static class members into the class body (vs. assigning them after the class definition). |
+| [jsdoc](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/jsdoc.ts) | Convert JSDoc @param types to TypeScript annotations. |
+| [member-accessibility](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts) | Add accessibility modifiers (private, protected, or public) to class members according to naming conventions. |
 | [react-class-lifecycle-methods](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/react-class-lifecycle-methods.ts) | Annotate React lifecycle method types. |
 | [react-class-state](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/react-class-state.ts) | Declare React state type. |
 | [react-default-props](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/react-default-props.ts) | Annotate React default props. |

--- a/packages/ts-migrate-plugins/src/index.ts
+++ b/packages/ts-migrate-plugins/src/index.ts
@@ -3,6 +3,7 @@ import declareMissingClassPropertiesPlugin from './plugins/declare-missing-class
 import eslintFixPlugin from './plugins/eslint-fix';
 import explicitAnyPlugin from './plugins/explicit-any';
 import hoistClassStaticsPlugin from './plugins/hoist-class-statics';
+import memberAccessibilityPlugin from './plugins/member-accessibility';
 import reactClassLifecycleMethodsPlugin from './plugins/react-class-lifecycle-methods';
 import reactClassStatePlugin from './plugins/react-class-state';
 import reactDefaultPropsPlugin from './plugins/react-default-props';
@@ -22,6 +23,7 @@ export {
   eslintFixPlugin,
   explicitAnyPlugin,
   hoistClassStaticsPlugin,
+  memberAccessibilityPlugin,
   reactClassLifecycleMethodsPlugin,
   reactClassStatePlugin,
   reactDefaultPropsPlugin,

--- a/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
+++ b/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
@@ -1,0 +1,87 @@
+/* eslint-disable no-bitwise */
+import ts from 'typescript';
+import { Plugin } from 'ts-migrate-server';
+
+type Options = {
+  defaultAccessibility?: 'private' | 'protected' | 'public';
+  privateRegex?: string;
+  protectedRegex?: string;
+  publicRegex?: string;
+};
+
+const memberAccessibilityPlugin: Plugin<Options> = {
+  name: 'member-accessibility',
+  run({ sourceFile, text, options }) {
+    const result = ts.transform<ts.SourceFile>(sourceFile, [
+      memberAccessibilityTransformerFactory(options),
+    ]);
+    const newSourceFile = result.transformed[0];
+    if (newSourceFile === sourceFile) {
+      return text;
+    }
+    const printer = ts.createPrinter();
+    return printer.printFile(newSourceFile);
+  },
+};
+
+export default memberAccessibilityPlugin;
+
+const accessibilityMask =
+  ts.ModifierFlags.Private | ts.ModifierFlags.Protected | ts.ModifierFlags.Public;
+
+const memberAccessibilityTransformerFactory = (options: Options) => (
+  context: ts.TransformationContext,
+) => {
+  let defaultAccessibility: ts.ModifierFlags;
+  switch (options.defaultAccessibility) {
+    case 'private':
+      defaultAccessibility = ts.ModifierFlags.Private;
+      break;
+    case 'protected':
+      defaultAccessibility = ts.ModifierFlags.Protected;
+      break;
+    case 'public':
+      defaultAccessibility = ts.ModifierFlags.Public;
+      break;
+    default:
+      defaultAccessibility = 0;
+      break;
+  }
+  const privateRegex = options.privateRegex ? new RegExp(options.privateRegex) : null;
+  const protectedRegex = options.protectedRegex ? new RegExp(options.protectedRegex) : null;
+  const publicRegex = options.publicRegex ? new RegExp(options.publicRegex) : null;
+
+  if (defaultAccessibility === 0 && !privateRegex && !protectedRegex && !publicRegex) {
+    // Nothing to do. Don't bother traversing the AST.
+    return <T extends ts.Node>(node: T) => node;
+  }
+  return visit;
+
+  function visit<T extends ts.Node>(origNode: T): T {
+    const node = ts.visitEachChild(origNode, visit, context);
+    if (ts.isClassElement(node) && node.name && ts.isIdentifier(node.name)) {
+      const modifierFlags = ts.getCombinedModifierFlags(node);
+      if ((modifierFlags & accessibilityMask) !== 0) {
+        // Don't overwrite existing modifier.
+        return node;
+      }
+
+      const name = node.name.text;
+      let accessibilityFlag = defaultAccessibility;
+      if (privateRegex?.test(name)) {
+        accessibilityFlag = ts.ModifierFlags.Private;
+      } else if (protectedRegex?.test(name)) {
+        accessibilityFlag = ts.ModifierFlags.Protected;
+      } else if (publicRegex?.test(name)) {
+        accessibilityFlag = ts.ModifierFlags.Public;
+      }
+
+      const newNode = ts.getMutableClone(node);
+      newNode.modifiers = ts.createNodeArray(
+        ts.createModifiersFromModifierFlags(modifierFlags | accessibilityFlag),
+      );
+      return newNode;
+    }
+    return node;
+  }
+};

--- a/packages/ts-migrate-plugins/tests/src/member-accessibility.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/member-accessibility.test.ts
@@ -1,0 +1,31 @@
+import { mockPluginParams } from '../test-utils';
+import memberAccessibilityPlugin from '../../src/plugins/member-accessibility';
+
+describe('member-accessibility plugin', () => {
+  it('adds accessibility modifiers to class elements', () => {
+    const text = `\
+class C {
+    _privateProperty: any;
+    static _privateStaticProperty: any;
+    _privateMethod() {}
+    get _privateGetter() {}
+    set _privateSetter(v) {}
+    public _looksPrivate() {}
+}`;
+
+    const result = memberAccessibilityPlugin.run(
+      mockPluginParams({ text, fileName: 'file.tsx', options: { privateRegex: '^_' } }),
+    );
+
+    expect(result).toBe(`\
+class C {
+    private _privateProperty: any;
+    private static _privateStaticProperty: any;
+    private _privateMethod() { }
+    private get _privateGetter() { }
+    private set _privateSetter(v) { }
+    public _looksPrivate() { }
+}
+`);
+  });
+});


### PR DESCRIPTION
This plugin adds accessibility modifiers (private, protected, or public) to class members according to naming conventions. Naming conventions are specified by regular expressions. A default accessibility modifier may also be specified.

With the default options, it does nothing.

## Configuration

The `privateRegex`, `protectedRegex`, and `publicRegex` options specify regular expressions as naming conventions for each accessibility level. If no regex is specified for a particular level, then that level is never used. If multiple regexes match on the same class member, the precedence is `private > protected > public`.

The `defaultAccessibility` option specifies a default accessibility for class members whose names don't match any regex. If none is specified, then these members are unchanged.

## Running

This plugin is included in the default `migrate` command because with the default options, it does nothing.

To mark members beginning with an underscore as private and others public, you may run:

```
npx ts-migrate -- migrate --default-accessibility public --private-regex '^_' frontend/foo
```

Closes #42.