### PR TITLE
Update typescript to 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "prettier": "^2.0.5",
     "react": "^16.12.0",
     "rimraf": "^3.0.0",
-    "ts-jest": "^26.2.0",
-    "typescript": "3.9.7"
+    "ts-jest": "^26.3.0",
+    "typescript": "4.0.2"
   },
   "workspaces": [
     "packages/*"

--- a/packages/ts-migrate-example/package.json
+++ b/packages/ts-migrate-example/package.json
@@ -12,6 +12,6 @@
     "ts-migrate-plugins": "^0.1.4",
     "ts-migrate-server": "^0.1.0",
     "ts-node": "^8.3.0",
-    "typescript": "3.9.7"
+    "typescript": "4.0.2"
   }
 }

--- a/packages/ts-migrate-plugins/package.json
+++ b/packages/ts-migrate-plugins/package.json
@@ -62,7 +62,7 @@
     "eslint": "^7.8.1",
     "jscodeshift": "^0.7.0",
     "ts-migrate-server": "^0.1.0",
-    "typescript": "3.9.7"
+    "typescript": "4.0.2"
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",
   "devDependencies": {

--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -1,7 +1,6 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
 import ts from 'typescript';
 import tsp from 'typescript/lib/protocol';
-import diagnosticMessages from 'typescript/lib/diagnosticMessages.generated.json';
 import { Plugin } from 'ts-migrate-server';
 import { isDiagnosticWithLinePosition } from '../utils/type-guards';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
@@ -18,13 +17,6 @@ const tsIgnorePlugin: Plugin<Options> = {
 };
 
 export default tsIgnorePlugin;
-
-const diagnosticMessagesByCode: { [code: string]: string } = {};
-Object.keys(diagnosticMessages).forEach((key) => {
-  const parts = key.split('_');
-  const code = parts[parts.length - 1];
-  diagnosticMessagesByCode[code] = diagnosticMessages[key as keyof typeof diagnosticMessages];
-});
 
 const TS_IGNORE_MESSAGE_LIMIT = 50;
 

--- a/packages/ts-migrate-plugins/src/plugins/utils/react-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/react-props.ts
@@ -222,8 +222,7 @@ function getTypeFromPropTypeExpression(
       const argument = node.arguments[0];
       if (ts.isArrayLiteralExpression(argument)) {
         const children: ts.Node[] = [];
-        result = ts.createUnionOrIntersectionTypeNode(
-          ts.SyntaxKind.UnionType,
+        result = ts.createUnionTypeNode(
           argument.elements.map((elm) => {
             const child = getTypeFromPropTypeExpression(elm, sourceFile, params);
             children.push(child);

--- a/packages/ts-migrate-server/package.json
+++ b/packages/ts-migrate-server/package.json
@@ -59,7 +59,7 @@
   "homepage": "https://github.com/airbnb/ts-migrate#readme",
   "license": "MIT",
   "dependencies": {
-    "typescript": "3.9.7",
+    "typescript": "4.0.2",
     "updatable-log": "^0.2.0"
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3"

--- a/packages/ts-migrate-server/src/tsserver/TSServer.ts
+++ b/packages/ts-migrate-server/src/tsserver/TSServer.ts
@@ -40,9 +40,7 @@ export default class TSServer {
     if (this.killed) return;
 
     this.childProcess.kill();
-    delete this.childProcess;
     this.emitter.removeAllListeners();
-    delete this.emitter;
     this.reader.dispose();
     this.logger.info('[TSServer] kill');
     this.killed = true;

--- a/packages/ts-migrate/package.json
+++ b/packages/ts-migrate/package.json
@@ -67,7 +67,7 @@
     "json5-writer": "^0.1.8",
     "ts-migrate-plugins": "^0.1.4",
     "ts-migrate-server": "^0.1.0",
-    "typescript": "3.9.7",
+    "typescript": "4.0.2",
     "updatable-log": "^0.2.0",
     "yargs": "^15.0.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -8775,10 +8775,10 @@ trim-off-newlines@^1.0.0:
   resolved "https://registry.yarnpkg.com/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz#9f9ba9d9efa8764c387698bcbfeb2c848f11adb3"
   integrity sha1-n5up2e+odkw4dpi8v+sshI8RrbM=
 
-ts-jest@^26.2.0:
-  version "26.2.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.2.0.tgz#7ec22faceb05ee1467fdb5265d1b33c27441f163"
-  integrity sha512-9+y2qwzXdAImgLSYLXAb/Rhq9+K4rbt0417b8ai987V60g2uoNWBBmMkYgutI7D8Zhu+IbCSHbBtrHxB9d7xyA==
+ts-jest@^26.3.0:
+  version "26.3.0"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.3.0.tgz#6b2845045347dce394f069bb59358253bc1338a9"
+  integrity sha512-Jq2uKfx6bPd9+JDpZNMBJMdMQUC3sJ08acISj8NXlVgR2d5OqslEHOR2KHMgwymu8h50+lKIm0m0xj/ioYdW2Q==
   dependencies:
     "@types/jest" "26.x"
     bs-logger "0.x"
@@ -8893,10 +8893,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.9.7:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.2.tgz#7ea7c88777c723c681e33bf7988be5d008d05ac2"
+  integrity sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==
 
 uglify-js@^3.1.4:
   version "3.10.1"


### PR DESCRIPTION
This updates TypeScript from 3.9.7 to 4.0.2. A couple motivations:

* I wanted to play with writing plugins using [ts-morph](https://github.com/dsherret/ts-morph) and had to use an older version so that it had the same TypeScript version as ts-migrate.
* It would be good to stay on top of the [factory deprecation changes](https://devblogs.microsoft.com/typescript/announcing-typescript-4-0/#usage-of-typescripts-node-factory-is-deprecated) that are happening, starting in 4.0.

There might be good reasons not to do this yet. I don't mind too much.