### PR TITLE
Add prop to specify the path to the tsconfig

### DIFF
--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -9,14 +9,15 @@ import { PluginParams } from '../../types';
 
 interface MigrateParams {
   rootDir: string;
+  tsConfigDir?: string;
   config: MigrateConfig;
   server: TSServer;
 }
 
-export default async function migrate({ rootDir, config, server }: MigrateParams): Promise<number> {
+export default async function migrate({ rootDir, tsConfigDir = rootDir, config, server }: MigrateParams): Promise<number> {
   let exitCode = 0;
 
-  const parseResult = parseTSConfig(rootDir);
+  const parseResult = parseTSConfig(tsConfigDir);
   const { options } = parseResult;
   const projectFileName = path.resolve(rootDir, '../..', parseResult.configFile);
   const fileNames = parseResult.fileNames.map((fileName) =>


### PR DESCRIPTION
This additional and optional prop will allow specifying the path to tsconfig separate from the migration directory (rootDir).
It might be clearer if tsConfigDir is the default rootDir rather than './'?

For example, if we want to specify migrate path where tsconfig doesn't exist
```js
migrate({
    rootDir: './models', // <- tsconfig doesn't exist in this folder
    tsConfigDir: './', // <- tsconfig exists here
})
```


P.S Thank you for this very helpful lib!