### PR TITLE
Use NodeFactory to create and update nodes

### DIFF
--- a/packages/ts-migrate-example/src/example-plugin-ts.ts
+++ b/packages/ts-migrate-example/src/example-plugin-ts.ts
@@ -29,24 +29,24 @@ const examplePluginTs: Plugin<Options> = {
 
       if (options.shouldReplaceText && hasTwoParams && multiplierReturn) {
         // create a new function declaration with a new type
-        const newFunctionDeclaration = ts.createFunctionDeclaration(
+        const newFunctionDeclaration = ts.factory.createFunctionDeclaration(
           functionDeclaration.decorators,
           functionDeclaration.modifiers,
           functionDeclaration.asteriskToken,
           functionDeclaration.name,
           functionDeclaration.typeParameters,
           functionDeclaration.parameters.map((x) =>
-            ts.createParameter(
+            ts.factory.createParameterDeclaration(
               x.decorators,
               x.modifiers,
               x.dotDotDotToken,
               x.name,
               x.questionToken,
-              ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+              ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
               x.initializer,
             ),
           ),
-          ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword),
           functionDeclaration.body,
         );
 

--- a/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
+++ b/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
@@ -32,6 +32,7 @@ const accessibilityMask =
 const memberAccessibilityTransformerFactory = (options: Options) => (
   context: ts.TransformationContext,
 ) => {
+  const { factory } = context;
   let defaultAccessibility: ts.ModifierFlags;
   switch (options.defaultAccessibility) {
     case 'private':
@@ -77,8 +78,8 @@ const memberAccessibilityTransformerFactory = (options: Options) => (
       }
 
       const newNode = ts.getMutableClone(node) as any;
-      newNode.modifiers = ts.createNodeArray(
-        ts.createModifiersFromModifierFlags(modifierFlags | accessibilityFlag),
+      newNode.modifiers = factory.createNodeArray(
+        factory.createModifiersFromModifierFlags(modifierFlags | accessibilityFlag),
       );
       return newNode;
     }

--- a/packages/ts-migrate-plugins/src/plugins/react-class-state.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-class-state.ts
@@ -59,9 +59,9 @@ const reactClassStatePlugin: Plugin<Options> = {
         const stateTypeName = getStateTypeName();
         const anyType =
           options.anyAlias != null
-            ? ts.createTypeReferenceNode(options.anyAlias, undefined)
-            : ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
-        const newStateType = ts.createTypeAliasDeclaration(
+            ? ts.factory.createTypeReferenceNode(options.anyAlias, undefined)
+            : ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+        const newStateType = ts.factory.createTypeAliasDeclaration(
           undefined,
           undefined,
           stateTypeName,
@@ -81,14 +81,10 @@ const reactClassStatePlugin: Plugin<Options> = {
           length: heritageType.end - heritageType.pos,
           text: ` ${printer.printNode(
             ts.EmitHint.Unspecified,
-            ts.updateExpressionWithTypeArguments(
-              heritageType,
-              [
-                propsType || ts.createTypeLiteralNode([]),
-                ts.createTypeReferenceNode(stateTypeName, undefined),
-              ],
-              heritageType.expression,
-            ),
+            ts.factory.updateExpressionWithTypeArguments(heritageType, heritageType.expression, [
+              propsType || ts.factory.createTypeLiteralNode([]),
+              ts.factory.createTypeReferenceNode(stateTypeName, undefined),
+            ]),
             sourceFile,
           )}`,
         });

--- a/packages/ts-migrate-plugins/src/plugins/react-default-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-default-props.ts
@@ -102,9 +102,9 @@ const reactDefaultPropsPlugin: Plugin<Options> = {
         ts.isIntersectionTypeNode(propsTypeAliasDeclaration.type) && indexOfTypeValue === -1;
 
       const propsTypeValueNode = ts.isIntersectionTypeNode(propsTypeAliasDeclaration.type)
-        ? ts.updateIntersectionTypeNode(
+        ? ts.factory.updateIntersectionTypeNode(
             propsTypeAliasDeclaration.type,
-            ts.createNodeArray(
+            ts.factory.createNodeArray(
               propsTypeAliasDeclaration.type.types.filter(
                 (_, k) => propTypesAreOnlyReferences || indexOfTypeValue === k,
               ),
@@ -120,11 +120,11 @@ const reactDefaultPropsPlugin: Plugin<Options> = {
 
       // rename type PropName -> type OwnPropName
       const updatedPropTypesName = doesPropsTypeHaveExport ? propsTypeName : `Own${propsTypeName}`;
-      const updatedPropTypeAlias = ts.updateTypeAliasDeclaration(
+      const updatedPropTypeAlias = ts.factory.updateTypeAliasDeclaration(
         propsTypeAliasDeclaration,
         propsTypeAliasDeclaration.decorators,
         propsTypeAliasDeclaration.modifiers,
-        ts.createIdentifier(updatedPropTypesName),
+        ts.factory.createIdentifier(updatedPropTypesName),
         propsTypeAliasDeclaration.typeParameters,
         propsTypeValueNode,
       );
@@ -136,26 +136,26 @@ const reactDefaultPropsPlugin: Plugin<Options> = {
 
       // create type Props = WithDefaultProps<OwnProps, typeof defaultProps> & types;
       const newPropsTypeValue = options.useDefaultPropsHelper
-        ? ts.createTypeReferenceNode(WITH_DEFAULT_PROPS_HELPER, [
-            ts.createTypeReferenceNode(updatedPropTypesName, undefined),
-            ts.createTypeQueryNode(ts.createIdentifier(defaultPropsTypeName)),
+        ? ts.factory.createTypeReferenceNode(WITH_DEFAULT_PROPS_HELPER, [
+            ts.factory.createTypeReferenceNode(updatedPropTypesName, undefined),
+            ts.factory.createTypeQueryNode(ts.factory.createIdentifier(defaultPropsTypeName)),
           ])
-        : ts.createIntersectionTypeNode([
-            ts.createTypeReferenceNode(updatedPropTypesName, undefined),
-            ts.createTypeQueryNode(ts.createIdentifier(defaultPropsTypeName)),
+        : ts.factory.createIntersectionTypeNode([
+            ts.factory.createTypeReferenceNode(updatedPropTypesName, undefined),
+            ts.factory.createTypeQueryNode(ts.factory.createIdentifier(defaultPropsTypeName)),
           ]);
 
       const componentPropsTypeName = doesPropsTypeHaveExport
         ? `Private${propsTypeName}`
         : propsTypeName;
 
-      const newPropsTypeAlias = ts.createTypeAliasDeclaration(
+      const newPropsTypeAlias = ts.factory.createTypeAliasDeclaration(
         undefined,
         undefined,
-        ts.createIdentifier(componentPropsTypeName),
+        ts.factory.createIdentifier(componentPropsTypeName),
         undefined,
         ts.isIntersectionTypeNode(propsTypeAliasDeclaration.type)
-          ? ts.createIntersectionTypeNode([
+          ? ts.factory.createIntersectionTypeNode([
               newPropsTypeValue,
               ...propsTypeAliasDeclaration.type.types.filter((el, k) =>
                 propTypesAreOnlyReferences
@@ -175,9 +175,9 @@ const reactDefaultPropsPlugin: Plugin<Options> = {
 
       // we should rename component prop type in that case
       if (doesPropsTypeHaveExport) {
-        const updatedComponentTypeReference = ts.updateTypeReferenceNode(
+        const updatedComponentTypeReference = ts.factory.updateTypeReferenceNode(
           componentTypeReference,
-          ts.createIdentifier(componentPropsTypeName),
+          ts.factory.createIdentifier(componentPropsTypeName),
           undefined,
         );
 
@@ -333,16 +333,20 @@ const reactDefaultPropsPlugin: Plugin<Options> = {
 // the target project might not have this as an internal dependency in project.json
 // It would have to be manually added, otherwise CI will complain about it
 function getWithDefaultPropsImport() {
-  return ts.createImportDeclaration(
+  return ts.factory.createImportDeclaration(
     undefined,
     undefined,
-    ts.createImportClause(
+    ts.factory.createImportClause(
+      false,
       undefined,
-      ts.createNamedImports([
-        ts.createImportSpecifier(undefined, ts.createIdentifier('WithDefaultProps')),
+      ts.factory.createNamedImports([
+        ts.factory.createImportSpecifier(
+          undefined,
+          ts.factory.createIdentifier('WithDefaultProps'),
+        ),
       ]),
     ),
-    ts.createStringLiteral(':ts-utils/types/WithDefaultProps'),
+    ts.factory.createStringLiteral(':ts-utils/types/WithDefaultProps'),
   );
 }
 

--- a/packages/ts-migrate-plugins/src/plugins/react-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-props.ts
@@ -96,7 +96,7 @@ const spreadReplacements: SpreadReplacement[] = [
       namedImport: 'withStylesPropTypes',
       moduleSpecifier: ':dls-themes/withStyles',
     },
-    typeRef: ts.createTypeReferenceNode('WithStylesProps', undefined),
+    typeRef: ts.factory.createTypeReferenceNode('WithStylesProps', undefined),
     typeImport: {
       namedImport: 'WithStylesProps',
       moduleSpecifier: ':dls-themes/withStyles',
@@ -108,7 +108,7 @@ const spreadReplacements: SpreadReplacement[] = [
       namedImport: 'withBreakpointPropTypes',
       moduleSpecifier: ':dls-core/components/breakpoints/withBreakpoint',
     },
-    typeRef: ts.createTypeReferenceNode('WithBreakpointProps', undefined),
+    typeRef: ts.factory.createTypeReferenceNode('WithBreakpointProps', undefined),
     typeImport: {
       namedImport: 'WithBreakpointProps',
       moduleSpecifier: ':dls-core/components/breakpoints/withBreakpoint',
@@ -120,8 +120,8 @@ const spreadReplacements: SpreadReplacement[] = [
       defaultImport: 'withRouterPropTypes',
       moduleSpecifier: ':routing/shapes/RR4PropTypes',
     },
-    typeRef: ts.createTypeReferenceNode('RouteConfigComponentProps', [
-      ts.createTypeLiteralNode([]),
+    typeRef: ts.factory.createTypeReferenceNode('RouteConfigComponentProps', [
+      ts.factory.createTypeLiteralNode([]),
     ]),
     typeImport: {
       namedImport: 'RouteConfigComponentProps',
@@ -181,13 +181,13 @@ function updatePropTypes(
             length: forwardRefComponent.expression.end - forwardRefComponent.expression.pos,
             text: ` ${printer.printNode(
               ts.EmitHint.Unspecified,
-              ts.updateExpressionWithTypeArguments(
+              ts.factory.updateExpressionWithTypeArguments(
                 forwardRefComponent as any,
-                [
-                  ts.createTypeReferenceNode(options.anyAlias || 'any', undefined),
-                  ts.createTypeReferenceNode(propsTypeName, undefined),
-                ].filter(isNotNull) as any,
                 forwardRefComponent.expression,
+                [
+                  ts.factory.createTypeReferenceNode(options.anyAlias || 'any', undefined),
+                  ts.factory.createTypeReferenceNode(propsTypeName, undefined),
+                ].filter(isNotNull) as any,
               ),
               sourceFile,
             )}`,
@@ -199,14 +199,14 @@ function updatePropTypes(
             length: propsParam.end - propsParam.pos,
             text: printer.printNode(
               ts.EmitHint.Unspecified,
-              ts.updateParameter(
+              ts.factory.updateParameterDeclaration(
                 propsParam,
                 propsParam.decorators,
                 propsParam.modifiers,
                 propsParam.dotDotDotToken,
                 propsParam.name,
                 propsParam.questionToken,
-                ts.createTypeReferenceNode(propsTypeName, undefined),
+                ts.factory.createTypeReferenceNode(propsTypeName, undefined),
                 propsParam.initializer,
               ),
               sourceFile,
@@ -235,12 +235,12 @@ function updatePropTypes(
           length: heritageType.end - heritageType.pos,
           text: ` ${printer.printNode(
             ts.EmitHint.Unspecified,
-            ts.updateExpressionWithTypeArguments(
+            ts.factory.updateExpressionWithTypeArguments(
               heritageType,
-              [ts.createTypeReferenceNode(propsTypeName, undefined), stateType].filter(
+              heritageType.expression,
+              [ts.factory.createTypeReferenceNode(propsTypeName, undefined), stateType].filter(
                 isNotNull,
               ) as any,
-              heritageType.expression,
             ),
             sourceFile,
           )}`,
@@ -277,7 +277,7 @@ function updateObjectLiteral(
     spreadReplacements,
     propTypeIdentifiers,
   });
-  let propsTypeAlias = ts.createTypeAliasDeclaration(
+  let propsTypeAlias = ts.factory.createTypeAliasDeclaration(
     undefined,
     undefined,
     propsTypeName,

--- a/packages/ts-migrate-plugins/src/plugins/react-shape.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-shape.ts
@@ -50,13 +50,13 @@ const reactShapePlugin: Plugin<Options> = {
         length: EXPORT_KEYWOARD.length + 1,
       });
 
-      const newExport = ts.createExportDeclaration(
+      const newExport = ts.factory.createExportDeclaration(
         undefined,
         undefined,
-        ts.createNamedExports([
-          ts.createExportSpecifier(undefined, ts.createIdentifier(shapeName)),
+        false,
+        ts.factory.createNamedExports([
+          ts.factory.createExportSpecifier(undefined, ts.factory.createIdentifier(shapeName)),
         ]),
-        undefined,
       );
       updates.push({
         kind: 'insert',
@@ -106,9 +106,10 @@ const reactShapePlugin: Plugin<Options> = {
                 )}`,
               });
             }
-            const updatedVariableDeclaration = ts.updateVariableDeclaration(
+            const updatedVariableDeclaration = ts.factory.updateVariableDeclaration(
               variableDeclaration,
               variableDeclaration.name,
+              undefined,
               getShapeTypeNode(shapeName),
               variableDeclaration.initializer,
             );
@@ -179,10 +180,17 @@ const reactShapePlugin: Plugin<Options> = {
           length: node.end,
           text: `${ts.sys.newLine}${printer.printNode(
             ts.EmitHint.Unspecified,
-            ts.createVariableStatement(
+            ts.factory.createVariableStatement(
               [],
-              ts.createVariableDeclarationList(
-                [ts.createVariableDeclaration(shapeName, getShapeTypeNode(shapeName), shapeNode)],
+              ts.factory.createVariableDeclarationList(
+                [
+                  ts.factory.createVariableDeclaration(
+                    shapeName,
+                    undefined,
+                    getShapeTypeNode(shapeName),
+                    shapeNode,
+                  ),
+                ],
                 ts.NodeFlags.Const,
               ),
             ),
@@ -192,11 +200,11 @@ const reactShapePlugin: Plugin<Options> = {
 
         const exportShapeExpression = `${ts.sys.newLine}${printer.printNode(
           ts.EmitHint.Unspecified,
-          ts.createExportAssignment(
+          ts.factory.createExportAssignment(
             undefined,
             undefined,
             undefined,
-            ts.createIdentifier(shapeName),
+            ts.factory.createIdentifier(shapeName),
           ),
           sourceFile,
         )}`;
@@ -228,12 +236,12 @@ function getTypeForTheShape(
       spreadReplacements: [],
     },
   );
-  const propsTypeAlias = ts.createTypeAliasDeclaration(
+  const propsTypeAlias = ts.factory.createTypeAliasDeclaration(
     undefined,
     undefined,
     shapeName,
     undefined,
-    isArrayShapeType ? ts.createArrayTypeNode(shapeTypeVariable) : shapeTypeVariable,
+    isArrayShapeType ? ts.factory.createArrayTypeNode(shapeTypeVariable) : shapeTypeVariable,
   );
   return ts.moveSyntheticComments(propsTypeAlias, shapeTypeVariable);
 }
@@ -251,19 +259,22 @@ function isPropTypesArrayOfShapes(node: ts.CallExpression) {
 }
 
 function getPropTypesImportNode() {
-  return ts.createImportDeclaration(
+  return ts.factory.createImportDeclaration(
     undefined,
     undefined,
-    ts.createImportClause(ts.createIdentifier('PropTypes'), undefined),
-    ts.createStringLiteral('prop-types'),
+    ts.factory.createImportClause(false, ts.factory.createIdentifier('PropTypes'), undefined),
+    ts.factory.createStringLiteral('prop-types'),
   );
 }
 
 // @TODO: PropTypes.Requireable<ShapeType> doesn't works with react-validators Shapes
 function getShapeTypeNode(shapeName: string) {
-  return ts.createTypeReferenceNode(
-    ts.createQualifiedName(ts.createIdentifier('PropTypes'), ts.createIdentifier('Requireable')),
-    [ts.createTypeReferenceNode(ts.createIdentifier(shapeName), undefined)],
+  return ts.factory.createTypeReferenceNode(
+    ts.factory.createQualifiedName(
+      ts.factory.createIdentifier('PropTypes'),
+      ts.factory.createIdentifier('Requireable'),
+    ),
+    [ts.factory.createTypeReferenceNode(ts.factory.createIdentifier(shapeName), undefined)],
   );
 }
 

--- a/packages/ts-migrate-plugins/src/plugins/utils/imports.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/imports.ts
@@ -63,11 +63,11 @@ export function updateImports(
       importClause.name &&
       !usedIdentifiers.has(importClause.name.text)
     ) {
-      importClause = ts.updateImportClause(
+      importClause = ts.factory.updateImportClause(
         importClause,
+        importClause.isTypeOnly,
         undefined,
         importClause.namedBindings,
-        importClause.isTypeOnly,
       );
     }
 
@@ -83,11 +83,11 @@ export function updateImports(
       .filter(isModuleSpecifier)
       .filter(isNotAdded);
     if (nameToAdd.length > 0 && importClause.name == null) {
-      importClause = ts.updateImportClause(
+      importClause = ts.factory.updateImportClause(
         importClause,
-        ts.createIdentifier(nameToAdd[0].defaultImport),
-        importClause.namedBindings,
         importClause.isTypeOnly,
+        ts.factory.createIdentifier(nameToAdd[0].defaultImport),
+        importClause.namedBindings,
       );
       added.add(nameToAdd[0]);
     }
@@ -98,11 +98,11 @@ export function updateImports(
       ts.isNamespaceImport(importClause.namedBindings) &&
       !usedIdentifiers.has(importClause.namedBindings.name.text)
     ) {
-      importClause = ts.updateImportClause(
+      importClause = ts.factory.updateImportClause(
         importClause,
+        importClause.isTypeOnly,
         importClause.name,
         undefined,
-        importClause.isTypeOnly,
       );
     }
 
@@ -129,13 +129,13 @@ export function updateImports(
         .forEach((cur) => added.add(cur));
 
       if (elements.length !== importClause.namedBindings.elements.length) {
-        importClause = ts.updateImportClause(
+        importClause = ts.factory.updateImportClause(
           importClause,
+          importClause.isTypeOnly,
           importClause.name,
           elements.length > 0
-            ? ts.updateNamedImports(importClause.namedBindings, elements)
+            ? ts.factory.updateNamedImports(importClause.namedBindings, elements)
             : undefined,
-          importClause.isTypeOnly,
         );
       }
     }
@@ -145,18 +145,21 @@ export function updateImports(
       .filter(isModuleSpecifier)
       .filter(isNotAdded);
     if (namedToAdd.length > 0) {
-      importClause = ts.updateImportClause(
+      importClause = ts.factory.updateImportClause(
         importClause,
+        importClause.isTypeOnly,
         importClause.name,
-        ts.createNamedImports([
+        ts.factory.createNamedImports([
           ...(importClause.namedBindings && ts.isNamedImports(importClause.namedBindings)
             ? importClause.namedBindings.elements
             : []),
           ...namedToAdd.map((cur) =>
-            ts.createImportSpecifier(undefined, ts.createIdentifier(cur.namedImport)),
+            ts.factory.createImportSpecifier(
+              undefined,
+              ts.factory.createIdentifier(cur.namedImport),
+            ),
           ),
         ]),
-        importClause.isTypeOnly,
       );
       namedToAdd.forEach((cur) => added.add(cur));
     }
@@ -176,7 +179,7 @@ export function updateImports(
       }
 
       if (numImports > 0) {
-        const upImpDec = ts.updateImportDeclaration(
+        const upImpDec = ts.factory.updateImportDeclaration(
           importDeclaration,
           importDeclaration.decorators,
           importDeclaration.modifiers,
@@ -220,41 +223,51 @@ export function updateImports(
 
       const namedImports =
         namedToAdd.length > 0
-          ? ts.createNamedImports(
+          ? ts.factory.createNamedImports(
               namedToAdd.map((cur) =>
-                ts.createImportSpecifier(undefined, ts.createIdentifier(cur.namedImport)),
+                ts.factory.createImportSpecifier(
+                  undefined,
+                  ts.factory.createIdentifier(cur.namedImport),
+                ),
               ),
             )
           : undefined;
 
       if (nameToAdd.length <= 1) {
         nodes.push(
-          ts.createImportDeclaration(
+          ts.factory.createImportDeclaration(
             undefined,
             undefined,
-            ts.createImportClause(
-              nameToAdd.length === 1 ? ts.createIdentifier(nameToAdd[0].defaultImport) : undefined,
+            ts.factory.createImportClause(
+              false,
+              nameToAdd.length === 1
+                ? ts.factory.createIdentifier(nameToAdd[0].defaultImport)
+                : undefined,
               namedImports,
             ),
-            ts.createStringLiteral(moduleSpecifier),
+            ts.factory.createStringLiteral(moduleSpecifier),
           ),
         );
       } else {
         nodes.push(
-          ts.createImportDeclaration(
+          ts.factory.createImportDeclaration(
             undefined,
             undefined,
-            ts.createImportClause(undefined, namedImports),
-            ts.createStringLiteral(moduleSpecifier),
+            ts.factory.createImportClause(false, undefined, namedImports),
+            ts.factory.createStringLiteral(moduleSpecifier),
           ),
         );
         nameToAdd.forEach((cur) => {
           nodes.push(
-            ts.createImportDeclaration(
+            ts.factory.createImportDeclaration(
               undefined,
               undefined,
-              ts.createImportClause(ts.createIdentifier(cur.defaultImport), undefined),
-              ts.createStringLiteral(moduleSpecifier),
+              ts.factory.createImportClause(
+                false,
+                ts.factory.createIdentifier(cur.defaultImport),
+                undefined,
+              ),
+              ts.factory.createStringLiteral(moduleSpecifier),
             ),
           );
         });

--- a/packages/ts-migrate-plugins/src/plugins/utils/react-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/react-props.ts
@@ -51,9 +51,11 @@ export default function getTypeFromPropTypesObjectLiteral(
     }
   }
 
-  let node: ts.TypeLiteralNode | ts.IntersectionTypeNode = ts.createTypeLiteralNode(members);
+  let node: ts.TypeLiteralNode | ts.IntersectionTypeNode = ts.factory.createTypeLiteralNode(
+    members,
+  );
   if (intersectionTypes.length > 0) {
-    node = ts.createIntersectionTypeNode([node, ...intersectionTypes]);
+    node = ts.factory.createIntersectionTypeNode([node, ...intersectionTypes]);
   }
   if (comments.length > 0) {
     node = ts.addSyntheticLeadingComment(
@@ -93,12 +95,11 @@ function convertPropertyAssignment(
 
   const typeNode = getTypeFromPropTypeExpression(typeExpression, sourceFile, params);
 
-  let propertySignature = ts.createPropertySignature(
+  let propertySignature = ts.factory.createPropertySignature(
     undefined,
     name,
-    isRequired ? undefined : ts.createToken(ts.SyntaxKind.QuestionToken),
+    isRequired ? undefined : ts.factory.createToken(ts.SyntaxKind.QuestionToken),
     typeNode,
-    undefined,
   );
   propertySignature = ts.moveSyntheticComments(propertySignature, typeNode);
   return propertySignature;
@@ -133,67 +134,75 @@ function getTypeFromPropTypeExpression(
      * PropTypes.any,
      */
     if (/string/.test(text)) {
-      result = ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
+      result = ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword);
     } else if (/any/.test(text)) {
       if (anyAlias) {
-        result = ts.createTypeReferenceNode(anyAlias, undefined);
+        result = ts.factory.createTypeReferenceNode(anyAlias, undefined);
       } else {
-        result = ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+        result = ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
       }
     } else if (/array/.test(text)) {
       if (anyAlias) {
-        result = ts.createArrayTypeNode(ts.createTypeReferenceNode(anyAlias, undefined));
-      } else {
-        result = ts.createArrayTypeNode(ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword));
-      }
-    } else if (/bool/.test(text)) {
-      result = ts.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
-    } else if (/number/.test(text)) {
-      result = ts.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
-    } else if (/object/.test(text)) {
-      if (anyAlias) {
-        result = ts.createTypeReferenceNode(anyAlias, undefined);
-      } else {
-        result = ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
-      }
-    } else if (/node/.test(text)) {
-      result = ts.createTypeReferenceNode('React.ReactNode', undefined);
-    } else if (/element/.test(text)) {
-      result = ts.createTypeReferenceNode('React.ReactElement', undefined);
-    } else if (/func/.test(text)) {
-      if (anyFunctionAlias) {
-        result = ts.createTypeReferenceNode(anyFunctionAlias, undefined);
-      } else if (anyAlias) {
-        result = ts.createFunctionTypeNode(
-          undefined,
-          [
-            ts.createParameter(
-              undefined,
-              undefined,
-              ts.createToken(ts.SyntaxKind.DotDotDotToken),
-              'args',
-              undefined,
-              ts.createArrayTypeNode(ts.createTypeReferenceNode(anyAlias, undefined)),
-              undefined,
-            ),
-          ],
-          ts.createTypeReferenceNode(anyAlias, undefined),
+        result = ts.factory.createArrayTypeNode(
+          ts.factory.createTypeReferenceNode(anyAlias, undefined),
         );
       } else {
-        result = ts.createFunctionTypeNode(
+        result = ts.factory.createArrayTypeNode(
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+        );
+      }
+    } else if (/bool/.test(text)) {
+      result = ts.factory.createKeywordTypeNode(ts.SyntaxKind.BooleanKeyword);
+    } else if (/number/.test(text)) {
+      result = ts.factory.createKeywordTypeNode(ts.SyntaxKind.NumberKeyword);
+    } else if (/object/.test(text)) {
+      if (anyAlias) {
+        result = ts.factory.createTypeReferenceNode(anyAlias, undefined);
+      } else {
+        result = ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+      }
+    } else if (/node/.test(text)) {
+      result = ts.factory.createTypeReferenceNode('React.ReactNode', undefined);
+    } else if (/element/.test(text)) {
+      result = ts.factory.createTypeReferenceNode('React.ReactElement', undefined);
+    } else if (/func/.test(text)) {
+      if (anyFunctionAlias) {
+        result = ts.factory.createTypeReferenceNode(anyFunctionAlias, undefined);
+      } else if (anyAlias) {
+        result = ts.factory.createFunctionTypeNode(
           undefined,
           [
-            ts.createParameter(
+            ts.factory.createParameterDeclaration(
               undefined,
               undefined,
-              ts.createToken(ts.SyntaxKind.DotDotDotToken),
+              ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
               'args',
               undefined,
-              ts.createArrayTypeNode(ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword)),
+              ts.factory.createArrayTypeNode(
+                ts.factory.createTypeReferenceNode(anyAlias, undefined),
+              ),
               undefined,
             ),
           ],
-          ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+          ts.factory.createTypeReferenceNode(anyAlias, undefined),
+        );
+      } else {
+        result = ts.factory.createFunctionTypeNode(
+          undefined,
+          [
+            ts.factory.createParameterDeclaration(
+              undefined,
+              undefined,
+              ts.factory.createToken(ts.SyntaxKind.DotDotDotToken),
+              'args',
+              undefined,
+              ts.factory.createArrayTypeNode(
+                ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
+              ),
+              undefined,
+            ),
+          ],
+          ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword),
         );
       }
     }
@@ -211,9 +220,9 @@ function getTypeFromPropTypeExpression(
       const argument = node.arguments[0];
       if (ts.isArrayLiteralExpression(argument)) {
         if (argument.elements.every((elm) => ts.isStringLiteral(elm) || ts.isNumericLiteral(elm))) {
-          result = ts.createUnionTypeNode(
+          result = ts.factory.createUnionTypeNode(
             (argument.elements as ts.NodeArray<ts.StringLiteral | ts.NumericLiteral>).map((elm) =>
-              ts.createLiteralTypeNode(elm),
+              ts.factory.createLiteralTypeNode(elm),
             ),
           );
         }
@@ -222,7 +231,7 @@ function getTypeFromPropTypeExpression(
       const argument = node.arguments[0];
       if (ts.isArrayLiteralExpression(argument)) {
         const children: ts.Node[] = [];
-        result = ts.createUnionTypeNode(
+        result = ts.factory.createUnionTypeNode(
           argument.elements.map((elm) => {
             const child = getTypeFromPropTypeExpression(elm, sourceFile, params);
             children.push(child);
@@ -237,25 +246,25 @@ function getTypeFromPropTypeExpression(
       const argument = node.arguments[0];
       if (argument) {
         const child = getTypeFromPropTypeExpression(argument, sourceFile, params);
-        result = ts.createArrayTypeNode(child);
+        result = ts.factory.createArrayTypeNode(child);
         result = ts.moveSyntheticComments(result, child);
       }
     } else if (/objectOf$/.test(expressionText)) {
       const argument = node.arguments[0];
       if (argument) {
         const child = getTypeFromPropTypeExpression(argument, sourceFile, params);
-        result = ts.createTypeLiteralNode([
-          ts.createIndexSignature(
+        result = ts.factory.createTypeLiteralNode([
+          ts.factory.createIndexSignature(
             undefined,
             undefined,
             [
-              ts.createParameter(
+              ts.factory.createParameterDeclaration(
                 undefined,
                 undefined,
                 undefined,
                 'key',
                 undefined,
-                ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+                ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
               ),
             ],
             child,
@@ -270,12 +279,12 @@ function getTypeFromPropTypeExpression(
       }
     }
   } else if (ts.isIdentifier(node) && node.text === 'textlike') {
-    result = ts.createUnionTypeNode([
-      ts.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
-      ts.createTypeReferenceNode('React.ReactNode', undefined),
+    result = ts.factory.createUnionTypeNode([
+      ts.factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+      ts.factory.createTypeReferenceNode('React.ReactNode', undefined),
     ]);
   } else if (ts.isIdentifier(node)) {
-    result = ts.createTypeReferenceNode(node.text, undefined);
+    result = ts.factory.createTypeReferenceNode(node.text, undefined);
   }
 
   /**
@@ -284,9 +293,9 @@ function getTypeFromPropTypeExpression(
    */
   if (!result) {
     if (anyAlias) {
-      result = ts.createTypeReferenceNode(anyAlias, undefined);
+      result = ts.factory.createTypeReferenceNode(anyAlias, undefined);
     } else {
-      result = ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+      result = ts.factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
     }
 
     // Add comment about what the original proptype was.


### PR DESCRIPTION
Most `ts.create*` and `ts.update*` functions are deprecated as of TypeScript 4.0. The current plan is to emit noisier and noisier warnings with each version until the deprecated functions are removed in 4.3.

See this pull request for more details: https://github.com/microsoft/TypeScript/pull/35282

Some method signatures and names have changed slightly.

The easy way to update is to use the global `ts.factory` object. TypeScript transformations also have access to a `NodeFactory` in their transformation contexts.

Note that we still use the deprecate `getMutableClone` function because its replacement is not included in the TypeScript declarations. See https://github.com/microsoft/TypeScript/issues/40507

I found uses of deprecated functions by searching code for the terms `ts.create` and `ts.update`. This turned up some false positives, such as calls to `ts.createPrinter`, which I ignored.