### PR TITLE
Allow ts-migrate to target specific files instead of the whole project

### DIFF
--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -25,12 +25,11 @@ export default async function migrate({
 
   const serverInitTimer = new PerfTimer();
 
+  // Normalize sources to be an array of full paths.
   if (sources !== undefined) {
-    if (Array.isArray(sources)) {
-      sources = sources.map((source) => path.join(rootDir, source));
-    } else {
-      sources = [sources];
-    }
+    sources = Array.isArray(sources) ? sources : [sources];
+    sources = sources.map((source) => path.join(rootDir, source));
+
     log.info(`Ignoring sources from tsconfig.json, using the ones provided manually instead.`);
   }
 

--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -40,6 +40,12 @@ export default async function migrate({
     addFilesFromTsConfig: sources === undefined,
   });
 
+  // If we passed in our own sources, let's add them to the project.
+  // If not, let's just get all the sources in the project.
+  if (sources) {
+    await project.addSourceFilesByPaths(sources);
+  }
+
   log.info(`Initialized tsserver project in ${serverInitTimer.elapsedStr()}.`);
 
   log.info('Start...');
@@ -53,16 +59,9 @@ export default async function migrate({
     const pluginTimer = new PerfTimer();
     log.info(`${pluginLogPrefix} Plugin ${i + 1} of ${config.plugins.length}. Start...`);
 
-    let sourceFiles: ts.SourceFile[] = [];
-
-    // If we passed in our own sources, let's add them to the project.
-    // If not, let's just get all the sources in the project.
-    if (sources) {
-      sourceFiles = await project.addSourceFilesByPaths(sources);
-    } else {
-      sourceFiles = project.getSourceFiles();
-    }
-    sourceFiles = sourceFiles.filter(({ fileName }) => !/(\.d\.ts|\.json)$/.test(fileName));
+    const sourceFiles = project
+      .getSourceFiles()
+      .filter(({ fileName }) => !/(\.d\.ts|\.json)$/.test(fileName));
 
     // eslint-disable-next-line no-restricted-syntax
     for (const sourceFile of sourceFiles) {

--- a/packages/ts-migrate/README.md
+++ b/packages/ts-migrate/README.md
@@ -18,7 +18,20 @@ Or [yarn](https://yarnpkg.com):
 
 # Usage
 
-`npx ts-migrate-full <folder>`
+Migrate an entire project like this:
+
+```sh
+npx ts-migrate-full <folder>
+```
+
+Or migrate individual parts of a project by specifying a subset of sources:
+
+```sh
+npx ts-migrate-full <folder> /                # specify the project root, and
+  --sources="relative/path/to/subset/**/*" /  # list the subset to migrate,
+  --sources="node_modules/**/*.d.ts"          # including any global types that the
+                                              # migrator may need to know about.
+```
 
 Or, you can run individual CLI commands:
 
@@ -29,9 +42,16 @@ npm run ts-migrate -- <command> [options]
 
 Commands:
   npm run ts-migrate -- init <folder>       Initialize tsconfig.json file in <folder>
-  npm run ts-migrate -- rename <folder>     Rename files in folder from JS/JSX to TS/TSX
-  npm run ts-migrate -- migrate <folder>    Fix TypeScript errors, using codemods
+  npm run ts-migrate -- rename <folder>     *Rename files in folder from JS/JSX to TS/TSX
+  npm run ts-migrate -- migrate <folder>    *Fix TypeScript errors, using codemods
   npm run ts-migrate -- reignore <folder>   Re-run ts-ignore on a project
+
+* These commands can be passed a --sources (or -s) flag. This flag accepts a relative
+path to a subset of your project as a string (glob patterns are allowed). When this flag
+is used, ts-migrate ignores your project's default source files in favor of the ones
+you've listed. It is effectively the same as replacing your tsconfig.json's `include`
+property with the provided sources. The flag can be passed multiple times.
+
 
 Options:
   -h,  -- help      Show help
@@ -58,6 +78,25 @@ For the second option we created a re-ignore script, which will fully automate t
 
 Usage: `npx ts-migrate -- reignore`.
 
+# Using `--sources` for partial migrations
+
+There are times in which migrating an entire project is too large a change. The `--sources` flag (or `-s` for short) allows you to run `ts-migrate` on a subset of your project by providing a set of sources to override the defaults specified in your tsconfig. `--sources` takes a relative path from the root of your project. It accepts globs, but remember to wrap any globs with quotes.
+
+```sh
+# Run everything on a sub-directory
+npx ts-migrate-full /path/to/your/project --sources "some/components/**/*"
+
+# Or run just one sub-command
+npx ts-migrate -- rename /path/to/your/project -s "some/components/**/*"
+```
+
+Because your project's default sources are ignored when `--sources` is used, it's a good idea to specify any ambient type files your project uses as well. Otherwise, `ts-migrate` might mark unidentifialbe globals as type errors, even when they aren't. For example, re-including ambient types from your node_modules folder looks like this:
+
+```sh
+npx ts-migrate-full /path/to/your/project \
+  --sources "some/components/**/*" \
+  --sources "node_modules/**/*.d.ts"
+```
 
 # FAQ
 
@@ -74,11 +113,6 @@ The ts-migrate codemods are only so smart. So, follow up is required to refine t
 > Um... ts-migrate broke my code! D:
 
 Please file the [issue here](https://github.com/airbnb/ts-migrate/issues/new).
-
-
-> Can I run ts-migrate on a single specific file within a frontend project?
-
-Unfortunately, you cannot run ts-migrate on a specific file. The easiest way would be to migrate the whole project. If you want, feel free to contribute to this functionality!
 
 
 > What is `$TSFixMe`?

--- a/packages/ts-migrate/bin/ts-migrate-full.sh
+++ b/packages/ts-migrate/bin/ts-migrate-full.sh
@@ -10,6 +10,7 @@ step_i=1
 step_count=4
 tsc_path="./node_modules/.bin/tsc"
 should_remove_eslintrc=false
+additional_args="${@:2}"
 
 
 echo "Welcome to TS Migrate! :D
@@ -66,7 +67,7 @@ if [ ! -f "$frontend_folder/tsconfig.json" ]; then
   $cli init $frontend_folder
 fi
 
-if [ ! -f "$frontend_folder/.eslintrc.*" ]; then
+if ! stat -t $frontend_folder/.eslintrc.* >/dev/null 2>&1; then
   touch $frontend_folder/.eslintrc
   should_remove_eslintrc=true
 fi
@@ -76,17 +77,17 @@ maybe_commit -m "[ts-migrate][$folder_name] Init tsconfig.json file" -m 'Co-auth
 echo "
 [Step $((step_i++)) of ${step_count}] Renaming files from JS/JSX to TS/TSX and updating project.json\...
 "
-$cli rename $frontend_folder
+$cli rename $frontend_folder $additional_args
 
 maybe_commit -m "[ts-migrate][$folder_name] Rename files from JS/JSX to TS/TSX" -m 'Co-authored-by: ts-migrate <>'
 
 echo "
 [Step $((step_i++)) of ${step_count}] Fixing TypeScript errors...
 "
-$cli migrate $frontend_folder
+$cli migrate $frontend_folder $additional_args
 
 if [ "$should_remove_eslintrc" = "true" ]; then
-  rm -f $frontend_folder/.eslintrc.*
+  rm -f $frontend_folder/.eslintrc
 fi
 
 maybe_commit -m "[ts-migrate][$folder_name] Run TS Migrate" -m 'Co-authored-by: ts-migrate <>'

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -51,10 +51,11 @@ yargs
   .command(
     'rename <folder>',
     'Rename files in folder from JS/JSX to TS/TSX',
-    (cmd) => cmd.positional('folder', { type: 'string' }).require(['folder']),
+    (cmd) => cmd.positional('folder', { type: 'string' }).string('sources').require(['folder']),
     (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);
-      const exitCode = rename({ rootDir });
+      const sources = args.sources;
+      const exitCode = rename({ rootDir, sources });
       process.exit(exitCode);
     },
   )
@@ -69,9 +70,11 @@ yargs
         .string('privateRegex')
         .string('protectedRegex')
         .string('publicRegex')
+        .string('sources')
         .require(['folder']),
     async (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);
+      const sources = args.sources;
       let config: MigrateConfig;
 
       if (args.plugin) {
@@ -146,7 +149,7 @@ yargs
           .addPlugin(eslintFixPlugin, {});
       }
 
-      const exitCode = await migrate({ rootDir, config });
+      const exitCode = await migrate({ rootDir, config, sources });
 
       process.exit(exitCode);
     },

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -49,18 +49,29 @@ yargs
     },
   )
   .command(
-    'rename <folder>',
+    'rename [options] <folder>',
     'Rename files in folder from JS/JSX to TS/TSX',
-    (cmd) => cmd.positional('folder', { type: 'string' }).string('sources').require(['folder']),
+    (cmd) =>
+      cmd
+        .positional('folder', { type: 'string' })
+        .string('sources')
+        .alias('sources', 's')
+        .describe('sources', 'Path to a subset of your project to rename.')
+        .example('$0 rename /frontend/foo', 'Rename all the files in /frontend/foo')
+        .example(
+          '$0 rename /frontend/foo -s "bar/**/*"',
+          'Rename all the files in /frontend/foo/bar',
+        )
+        .require(['folder']),
     (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);
-      const sources = args.sources;
+      const { sources } = args;
       const exitCode = rename({ rootDir, sources });
       process.exit(exitCode);
     },
   )
   .command(
-    'migrate <folder>',
+    'migrate [options] <folder>',
     'Fix TypeScript errors, using codemods',
     (cmd) =>
       cmd
@@ -71,10 +82,17 @@ yargs
         .string('protectedRegex')
         .string('publicRegex')
         .string('sources')
+        .alias('sources', 's')
+        .describe('sources', 'Path to a subset of your project to rename (globs are ok).')
+        .example('migrate /frontend/foo', 'Migrate all the files in /frontend/foo')
+        .example(
+          '$0 migrate /frontend/foo -s "bar/**/*" -s "node_modules/**/*.d.ts"',
+          'Migrate all the files in /frontend/foo/bar, accounting for ambient types from node_modules.',
+        )
         .require(['folder']),
     async (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);
-      const sources = args.sources;
+      const { sources } = args;
       let config: MigrateConfig;
 
       if (args.plugin) {
@@ -196,16 +214,22 @@ yargs
     },
   )
   .example('$0 --help', 'Show help')
+  .example('$0 migrate --help', 'Show help for the migrate command')
   .example('$0 init frontend/foo', 'Create tsconfig.json file at frontend/foo/tsconfig.json')
   .example(
     '$0 init:extended frontend/foo',
     'Create extended from the base tsconfig.json file at frontend/foo/tsconfig.json',
   )
   .example('$0 rename frontend/foo', 'Rename files in frontend/foo from JS/JSX to TS/TSX')
+  .example(
+    '$0 rename frontend/foo --s "bar/baz"',
+    'Rename files in frontend/foo/bar/baz from JS/JSX to TS/TSX',
+  )
   .demandCommand(1, 'Must provide a command.')
   .help('h')
   .alias('h', 'help')
   .alias('i', 'init')
   .alias('m', 'migrate')
   .alias('rn', 'rename')
-  .alias('ri', 'reignore').argv;
+  .alias('ri', 'reignore')
+  .wrap(Math.min(yargs.terminalWidth(), 100)).argv;

--- a/packages/ts-migrate/commands/rename.ts
+++ b/packages/ts-migrate/commands/rename.ts
@@ -74,8 +74,12 @@ function findJSFiles(rootDir: string, configFile: string, sources?: string | str
 
   let { include } = config;
 
+  // Sources come from either `config.files` or `config.includes`.
+  // If the --sources flag is set, let's ignore both of those config properties
+  // and set our own `config.includes` instead.
   if (sources !== undefined) {
     include = Array.isArray(sources) ? sources : [sources];
+    delete config.files;
   }
 
   const { fileNames, errors } = ts.parseJsonConfigFileContent(

--- a/packages/ts-migrate/commands/rename.ts
+++ b/packages/ts-migrate/commands/rename.ts
@@ -8,9 +8,10 @@ import json5Writer from 'json5-writer';
 
 interface RenameParams {
   rootDir: string;
+  sources?: string | string[];
 }
 
-export default function rename({ rootDir }: RenameParams): number {
+export default function rename({ rootDir, sources }: RenameParams): number {
   const configFile = path.resolve(rootDir, 'tsconfig.json');
   if (!fs.existsSync(configFile)) {
     log.error('Could not find tsconfig.json at', configFile);
@@ -19,7 +20,7 @@ export default function rename({ rootDir }: RenameParams): number {
 
   let jsFiles: string[];
   try {
-    jsFiles = findJSFiles(rootDir, configFile);
+    jsFiles = findJSFiles(rootDir, configFile, sources);
   } catch (err) {
     log.error(err);
     return -1;
@@ -57,7 +58,7 @@ export default function rename({ rootDir }: RenameParams): number {
   return 0;
 }
 
-function findJSFiles(rootDir: string, configFile: string) {
+function findJSFiles(rootDir: string, configFile: string, sources?: string | string[]) {
   const configFileContents = ts.sys.readFile(configFile);
   if (configFileContents == null) {
     throw new Error(`Failed to read TypeScript config file: ${configFile}`);
@@ -71,6 +72,12 @@ function findJSFiles(rootDir: string, configFile: string) {
     );
   }
 
+  let { include } = config;
+
+  if (sources !== undefined) {
+    include = Array.isArray(sources) ? sources : [sources];
+  }
+
   const { fileNames, errors } = ts.parseJsonConfigFileContent(
     {
       ...config,
@@ -79,6 +86,7 @@ function findJSFiles(rootDir: string, configFile: string) {
         // Force JS/JSX files to be included
         allowJs: true,
       },
+      include,
     },
     ts.sys,
     rootDir,


### PR DESCRIPTION
Hey there!

I'm working on migrating pieces of Etsy's codebase to TypeScript. This project seemed like a good resource for exactly that, but we have some restrictions that prevent an all-at-once migration just yet. [I noticed](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate/README.md#faq) that you might be open to a contribution to enable migrating individual files, and this PR is that contribution.

### What is the change?

This PR adds a `--sources` flag that accepts a string or a glob expression representing a path to migrate. The path has to be relative to the root directory of the project. `--sources` can be used multiple times to provide multiple paths.

Using it looks like this right now:

```sh
yarn ts-migrate migrate \                  # "rename" works too
    --sources="modules/to/migrate/**/*" \  # The files we want to migrate
    --sources="node_modules/**/*.d.ts" \   # Ambient types from node_modules
    --sources="@types/**/*.d.ts" \         # Ambient types from our repo
    /path/to/our/repository
```

Specifying sources tells `ts-migrate` to ignore the sources defined in a project's `tsconfig.json` in favor of the ones passed in. The one downside of this is that ambient type files aren't loaded. `ts-migrate` works mostly ok without them, but it yells about globals that it can't identify, as you might expect. Adding ambient types back is as easy as passing another `--sources` parameter, like I did in the example above.

### What isn't done yet?

This appears to work as expected for me, but this PR still probably need these updates:
- [ ] `ts-migrate-full` doesn't know about `--sources` yet, which might be useful
- [ ] `rename` doesn't account for tsconfigs with a `files` array yet (I assume I need to just unset it, but I want to test that on a config that actually has a `files` property).
- [ ] Updating docs and writing tests, of course.

### Questions and notes.

This PR isn't fully finished, but I wanted to share the changes earlier rather than later to get some feedback on whether or not this is a good approach. Here are some notes:
- I opted to keep using the tsconfig in `rename`, rather than bypassing `findJsFiles` altogether, to ensure that whatever validation `ts.parseJsonConfigFileContent` performs continues to get applied.
- In `ts-migrate-server`, I used `addFilesFromTsConfig` when initializing the project, rather than starting the project as normal and filtering down to the provided source files. I did this because it sped up initialization and memory usage considerably in larger repos (I'm dealing with one that has around 10k files). In general, I assumed that using `--sources` implied that the runtime should be relatively quick when possible.

Let me know your thoughts, and thank you for open-sourcing this tool in the first place!