### PR TITLE
Basic GitHub Actions-based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: ['10', '12', '14']
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node_version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node_version }}
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+
+      - name: Run `lint`
+        run: yarn lint
+
+      - name: Run `build`
+        run: yarn build
+
+      - name: Run `test`
+        run: yarn test


### PR DESCRIPTION
Some form of CI in this repo would be useful. I've essentially copied the simple CI setup from another Airbnb project, [goji-js](https://github.com/airbnb/goji-js/blob/master/.github/workflows/ci.yml). It lints, builds, and runs tests on all LTS Node versions.

You can see an example of a passing run [here](https://github.com/edsrzf/ts-migrate/actions/runs/410173802). 