### PR TITLE
Replace getDiagnostics with getLanguageService

### DIFF
--- a/packages/ts-migrate-plugins/README.md
+++ b/packages/ts-migrate-plugins/README.md
@@ -84,15 +84,7 @@ interface PluginParams<TPluginOptions = {}> {
   rootDir: string;
   text: string;
   sourceFile: ts.SourceFile;
-  getDiagnostics: () => Promise<PluginDiagnostics>;
-}
-
-export type Diagnostic = tsp.Diagnostic | tsp.DiagnosticWithLinePosition;
-
-export interface PluginDiagnostics {
-  semanticDiagnostics: Diagnostic[];
-  syntacticDiagnostics: Diagnostic[];
-  suggestionDiagnostics: Diagnostic[];
+  getLanguageService: () => ts.LanguageService;
 }
 ```
 

--- a/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts
+++ b/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts
@@ -8,8 +8,9 @@ const j = jscodeshift.withParser('tsx');
 
 const declareMissingClassPropertiesPlugin: Plugin<Options> = {
   name: 'declare-missing-class-properties',
-  async run({ text, getDiagnostics, options }) {
-    const diagnostics = (await getDiagnostics()).semanticDiagnostics
+  async run({ text, fileName, getLanguageService, options }) {
+    const diagnostics = getLanguageService()
+      .getSemanticDiagnostics(fileName)
       .filter(isDiagnosticWithLinePosition)
       .filter((diagnostic) => diagnostic.code === 2339 || diagnostic.code === 2551);
 

--- a/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
+++ b/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
@@ -8,8 +8,8 @@ type Options = { anyAlias?: string };
 
 const explicitAnyPlugin: Plugin<Options> = {
   name: 'explicit-any',
-  run({ options, text, getDiagnostics }) {
-    const { semanticDiagnostics } = getDiagnostics();
+  run({ options, fileName, text, getLanguageService }) {
+    const semanticDiagnostics = getLanguageService().getSemanticDiagnostics(fileName);
     const diagnostics = semanticDiagnostics
       .filter(isDiagnosticWithLinePosition)
       .filter((d) => d.category === ts.DiagnosticCategory.Error);

--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -8,9 +8,10 @@ type Options = { useTsIgnore?: boolean };
 
 const tsIgnorePlugin: Plugin<Options> = {
   name: 'ts-ignore',
-  run({ getDiagnostics, sourceFile, options }) {
-    const allDiagnostics = getDiagnostics();
-    const diagnostics = allDiagnostics.semanticDiagnostics.filter(isDiagnosticWithLinePosition);
+  run({ getLanguageService, fileName, sourceFile, options }) {
+    const diagnostics = getLanguageService()
+      .getSemanticDiagnostics(fileName)
+      .filter(isDiagnosticWithLinePosition);
     return getTextWithIgnores(sourceFile, diagnostics, options);
   },
 };

--- a/packages/ts-migrate-plugins/tests/test-utils.ts
+++ b/packages/ts-migrate-plugins/tests/test-utils.ts
@@ -38,11 +38,12 @@ export function mockPluginParams<TOptions = unknown>(params: {
     rootDir: __dirname,
     text,
     sourceFile,
-    getDiagnostics: () => ({
-      semanticDiagnostics: semanticDiagnostics.map(withFile),
-      syntacticDiagnostics: syntacticDiagnostics.map(withFile),
-      suggestionDiagnostics: suggestionDiagnostics.map(withFile),
-    }),
+    getLanguageService: () =>
+      ({
+        getSemanticDiagnostics: () => semanticDiagnostics.map(withFile),
+        getSyntacticDiagnostics: () => syntacticDiagnostics.map(withFile),
+        getSuggestionDiagnostics: () => suggestionDiagnostics.map(withFile),
+      } as any),
   };
 }
 

--- a/packages/ts-migrate-server/src/index.ts
+++ b/packages/ts-migrate-server/src/index.ts
@@ -1,12 +1,7 @@
 import migrate, { MigrateConfig } from './migrate';
-import {
-  Plugin as PluginType,
-  PluginParams as Params,
-  PluginDiagnostics as Diagnostocs,
-} from '../types';
+import { Plugin as PluginType, PluginParams as Params } from '../types';
 
 export type Plugin<T = unknown> = PluginType<T>;
 export type PluginParams<TPluginOptions = unknown> = Params<TPluginOptions>;
-export type PluginDiagnostics = Diagnostocs;
 
 export { migrate, MigrateConfig };

--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -69,20 +69,7 @@ export default async function migrate({
       const relFile = path.relative(rootDir, sourceFile.fileName);
       const fileLogPrefix = `${pluginLogPrefix}[${relFile}]`;
 
-      const getDiagnostics = () => {
-        const languageService = project.getLanguageService();
-        const semanticDiagnostics = languageService.getSemanticDiagnostics(fileName);
-
-        const syntacticDiagnostics = languageService.getSyntacticDiagnostics(fileName);
-
-        const suggestionDiagnostics = languageService.getSuggestionDiagnostics(fileName);
-
-        return {
-          semanticDiagnostics,
-          syntacticDiagnostics,
-          suggestionDiagnostics,
-        };
-      };
+      const getLanguageService = () => project.getLanguageService();
 
       const params: PluginParams<unknown> = {
         fileName,
@@ -90,7 +77,7 @@ export default async function migrate({
         sourceFile,
         text: sourceFile.text,
         options: pluginOptions,
-        getDiagnostics,
+        getLanguageService,
       };
       try {
         // eslint-disable-next-line no-await-in-loop

--- a/packages/ts-migrate-server/types/index.ts
+++ b/packages/ts-migrate-server/types/index.ts
@@ -7,13 +7,7 @@ export interface PluginParams<TPluginOptions> {
   rootDir: string;
   text: string;
   sourceFile: ts.SourceFile;
-  getDiagnostics: () => PluginDiagnostics;
-}
-
-export interface PluginDiagnostics {
-  semanticDiagnostics: ts.Diagnostic[];
-  syntacticDiagnostics: ts.DiagnosticWithLocation[];
-  suggestionDiagnostics: ts.DiagnosticWithLocation[];
+  getLanguageService: () => ts.LanguageService;
 }
 
 export type PluginResult = string | void;

--- a/packages/ts-migrate/tests/commands/migrate/migrate.test.ts
+++ b/packages/ts-migrate/tests/commands/migrate/migrate.test.ts
@@ -33,5 +33,5 @@ describe('migrate command', () => {
     const [rootData, outputData] = getDirData(rootDir, outputDir);
     expect(rootData).toEqual(outputData);
     expect(exitCode).toBe(0);
-  });
+  }, 10000);
 });


### PR DESCRIPTION
The TypeScript API's `LanguageService` provides the ability to get diagnostics as well as many other capabilities. Since introducing `@ts-morph/bootstrap` in #49 we can now get easy access to it. (This change was discussed as a likely future change in that PR.)