### PR TITLE
Test explicit-any against real diagnostics

### DIFF
--- a/packages/ts-migrate-plugins/package.json
+++ b/packages/ts-migrate-plugins/package.json
@@ -66,6 +66,7 @@
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",
   "devDependencies": {
+    "@ts-morph/bootstrap": "^0.8.0",
     "jest": "^26.4.2"
   }
 }

--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -1,26 +1,26 @@
 import ts from 'typescript';
-import { mockPluginParams, mockDiagnostic } from '../test-utils';
+import { mockPluginParams, mockDiagnostic, realPluginParams } from '../test-utils';
 import explicitAnyPlugin from '../../src/plugins/explicit-any';
 
 describe('explicit-any plugin', () => {
   it('adds explicit any', async () => {
-    const text = `import specifier1 from '../source';
+    const text = `let somePromise: any;
 somePromise.then(res1 => res1.default || res1);
 somePromise.then((res2) => res2.default || res2);
+let someArray: any;
 someArray.forEach(({ arg1, arg2 }) => {});
-const { dest1, dest2 } = obj;
 function fn1(p1, p2) {}
 const fn2 = function(p3, p4) {}
-const var1 = [];
-function fn3(p5 = {}) {const {arg3} = p5}
+function f3() {
+  const var1 = [];
+  return var1;
+}
 function fn4({ arg4: { arg5, arg_6: arg6 } }) {}
-type Fn5Params = {};
-function fn5({ arg7: { arg8 } }: Fn5Params) {}
 const {
   root_see_all_link_text: rootSeeAllLinkText,
   root_subtitle: rootSubtitle,
   root_title: rootTitle,
-} = cancellationModule || {};
+} = {};
 function Foo({
   paramA,
   paramB,
@@ -31,78 +31,37 @@ function Foo({
 }
 const { varA, varB: {
   inVarA, inVarB,
-} = {} } = state;
-const { deepobjA = {
-  deepobjB = { deepobjC = {} } = {},
 } = {} } = {};
 `;
 
-    const diagnosticFor = (str: string, code: number) =>
-      mockDiagnostic(text, str, { category: ts.DiagnosticCategory.Error, code });
-
     const result = await explicitAnyPlugin.run(
-      mockPluginParams({
+      await realPluginParams({
         text,
-        semanticDiagnostics: [
-          diagnosticFor('specifier1', 7034),
-          diagnosticFor('res1', 7006),
-          diagnosticFor('res2', 7006),
-          diagnosticFor('arg1', 7031),
-          diagnosticFor('arg2', 7031),
-          diagnosticFor('dest1', 7031),
-          diagnosticFor('dest2', 7031),
-          diagnosticFor('p1', 7006),
-          diagnosticFor('p2', 7006),
-          diagnosticFor('p3', 7006),
-          diagnosticFor('p4', 7006),
-          diagnosticFor('var1', 7034),
-          diagnosticFor('arg3', 2459),
-          diagnosticFor('arg5', 7031),
-          diagnosticFor('arg6', 7031),
-          diagnosticFor('arg8', 7031),
-          diagnosticFor('root_see_all_link_text', 2525),
-          diagnosticFor('root_subtitle', 2525),
-          diagnosticFor('root_title', 2525),
-          diagnosticFor('paramA', 2525),
-          diagnosticFor('paramB', 2525),
-          diagnosticFor('paramC', 2525),
-          diagnosticFor('paramD', 2525),
-          diagnosticFor('varA', 2525),
-          diagnosticFor('varB', 2525),
-          diagnosticFor('inVarA', 2525),
-          diagnosticFor('inVarB', 2525),
-          diagnosticFor('deepobjA', 2525),
-          diagnosticFor('deepobjB', 2525),
-          diagnosticFor('deepobjC', 2525),
-        ],
       }),
     );
 
-    expect(result).toBe(`import specifier1 from '../source';
+    expect(result).toBe(`let somePromise: any;
 somePromise.then((res1: any) => res1.default || res1);
 somePromise.then((res2: any) => res2.default || res2);
+let someArray: any;
 someArray.forEach(({
   arg1,
   arg2
 }: any) => {});
-const {
-  dest1,
-  dest2
-}: any = obj;
 function fn1(p1: any, p2: any) {}
 const fn2 = function(p3: any, p4: any) {}
-const var1: any = [];
-function fn3(p5: any = {}) {const {arg3} = p5}
+function f3() {
+  const var1: any = [];
+  return var1;
+}
 function fn4({
   arg4: { arg5, arg_6: arg6 }
 }: any) {}
-type Fn5Params = {};
-function fn5({ arg7: { arg8 } }: Fn5Params) {}
 const {
   root_see_all_link_text: rootSeeAllLinkText,
   root_subtitle: rootSubtitle,
   root_title: rootTitle
-}: any = cancellationModule || {};
+}: any = {};
 function Foo({
   paramA,
   paramB,
@@ -117,11 +76,6 @@ const {
   varB: {
     inVarA, inVarB,
   } = {}
-}: any = state;
-const {
-  deepobjA = ({
-    deepobjB = ({ deepobjC = {} } = {}),
-  } = {})
 }: any = {};
 `);
   });

--- a/packages/ts-migrate-plugins/tests/test-utils.ts
+++ b/packages/ts-migrate-plugins/tests/test-utils.ts
@@ -1,3 +1,4 @@
+import { createProject } from '@ts-morph/bootstrap';
 import ts from 'typescript';
 import { PluginParams } from 'ts-migrate-server';
 
@@ -64,5 +65,32 @@ export function mockDiagnostic(
     category: ts.DiagnosticCategory.Error,
     code: 123,
     ...overrides,
+  };
+}
+
+export async function realPluginParams<TOptions = unknown>(params: {
+  fileName?: string;
+  text?: string;
+  options?: TOptions;
+}): Promise<PluginParams<TOptions>> {
+  const { fileName = 'file.ts', text = '', options = {} } = params;
+
+  const project = await createProject({
+    compilerOptions: {
+      strict: true,
+    },
+    useInMemoryFileSystem: true,
+  });
+  const sourceFile = project.createSourceFile(fileName, text);
+
+  const getLanguageService = () => project.getLanguageService();
+
+  return {
+    options: (options as unknown) as TOptions,
+    fileName,
+    rootDir: __dirname,
+    text,
+    sourceFile,
+    getLanguageService,
   };
 }


### PR DESCRIPTION
With `@ts-morph/bootstrap` it's relatively easy to set up tests to get real diagnostics, and the performance difference compared to mock diagnostics is not really noticeable.

I think it's worth testing explicit-any against real diagnostics to be sure that the test cases are representative of real scenarios, and to help give us confidence when upgrading to newer versions of TypeScript, which may change diagnostic behavior.

To make this work I did have to change some of the test cases and I'll note the specific reasons in my inline comments.