### PR TITLE
Don't add accessibility modifiers to object literals

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
+++ b/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
@@ -58,7 +58,12 @@ const memberAccessibilityTransformerFactory = (options: Options) => (
 
   function visit(origNode: ts.Node): ts.Node {
     const node = ts.visitEachChild(origNode, visit, context);
-    if (ts.isClassElement(node) && node.name && ts.isIdentifier(node.name)) {
+    if (
+      ts.isClassElement(node) &&
+      ts.isClassLike(node.parent) &&
+      node.name &&
+      ts.isIdentifier(node.name)
+    ) {
       const modifierFlags = ts.getCombinedModifierFlags(node);
       if ((modifierFlags & accessibilityMask) !== 0) {
         // Don't overwrite existing modifier.

--- a/packages/ts-migrate-plugins/tests/src/member-accessibility.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/member-accessibility.test.ts
@@ -28,4 +28,20 @@ class C {
 }
 `);
   });
+
+  it('does not add accessibility modifiers to object literals', () => {
+    const text = `\
+const o = {
+    _privateMethod() {},
+    publicMethod() {},
+    get _privateGetter() {},
+    set _privateSetter(v) {}
+}`;
+
+    const result = memberAccessibilityPlugin.run(
+      mockPluginParams({ text, fileName: 'file.tsx', options: { privateRegex: '^_' } }),
+    );
+
+    expect(result).toBe(text);
+  });
 });


### PR DESCRIPTION
This addresses a bug in the member accessibility plugin by making sure that class element is actually inside a class.