### PR TITLE
Proposal: JSON configuration file to control plugins

### DIFF
--- a/packages/ts-migrate/config.ts
+++ b/packages/ts-migrate/config.ts
@@ -1,0 +1,133 @@
+import fs from 'fs';
+import log from 'updatable-log';
+import { MigrateConfig } from 'ts-migrate-server';
+
+import {
+  declareMissingClassPropertiesPlugin,
+  eslintFixPlugin,
+  explicitAnyPlugin,
+  hoistClassStaticsPlugin,
+  jsDocPlugin,
+  memberAccessibilityPlugin,
+  reactClassLifecycleMethodsPlugin,
+  reactClassStatePlugin,
+  reactDefaultPropsPlugin,
+  reactPropsPlugin,
+  reactShapePlugin,
+  stripTSIgnorePlugin,
+  tsIgnorePlugin,
+} from 'ts-migrate-plugins';
+
+const availablePlugins = [
+  declareMissingClassPropertiesPlugin,
+  eslintFixPlugin,
+  explicitAnyPlugin,
+  hoistClassStaticsPlugin,
+  jsDocPlugin,
+  memberAccessibilityPlugin,
+  reactClassLifecycleMethodsPlugin,
+  reactClassStatePlugin,
+  reactDefaultPropsPlugin,
+  reactPropsPlugin,
+  reactShapePlugin,
+  stripTSIgnorePlugin,
+  tsIgnorePlugin,
+];
+
+interface MigrateConfigJson {
+  globalOptions?: Record<string, unknown>;
+  plugins: PluginConfigJson[];
+}
+
+interface PluginConfigJson {
+  name: string;
+  options?: Record<string, unknown>;
+}
+
+function migrateConfigFromJson(json: MigrateConfigJson): MigrateConfig {
+  const config = new MigrateConfig();
+  json.plugins.forEach((pluginJson) => {
+    const plugin = availablePlugins.find((cur) => cur.name === pluginJson.name);
+    if (!plugin) {
+      log.error(`Could not find a plugin named ${pluginJson.name}.`);
+      process.exit(1);
+    }
+    config.addPlugin(plugin, { ...json.globalOptions, ...pluginJson.options });
+  });
+  return config;
+}
+
+export function migrateConfigFromFile(path: string): MigrateConfig {
+  return migrateConfigFromJson(JSON.parse(fs.readFileSync(path).toString()));
+}
+
+interface Args {
+  aliases?: string;
+  defaultAccessibility?: 'private' | 'protected' | 'public';
+  privateRegex?: string;
+  protectedRegex?: string;
+  publicRegex?: string;
+  typeMap?: string;
+  useDefaultPropsHelper?: string;
+}
+
+export function singlePluginConfig(pluginName: string, args: Args): MigrateConfig {
+  return migrateConfigFromJson({
+    globalOptions: {
+      anyAlias: args.aliases === 'tsfixme' ? '$TSFixMe' : undefined,
+    },
+    plugins: [
+      {
+        name: pluginName,
+        options: {
+          typeMap: pluginName === 'jsdoc' && args.typeMap ? JSON.parse(args.typeMap) : undefined,
+        },
+      },
+    ],
+  });
+}
+
+export function defaultMigrateConfig(args: Args): MigrateConfig {
+  const airbnbAnyAlias = '$TSFixMe';
+  const airbnbAnyFunctionAlias = '$TSFixMeFunction';
+  // by default, we're not going to use any aliases in ts-migrate
+  const anyAlias = args.aliases === 'tsfixme' ? airbnbAnyAlias : undefined;
+  const anyFunctionAlias = args.aliases === 'tsfixme' ? airbnbAnyFunctionAlias : undefined;
+  const useDefaultPropsHelper = args.useDefaultPropsHelper === 'true';
+
+  const { defaultAccessibility, privateRegex, protectedRegex, publicRegex } = args;
+
+  return (
+    new MigrateConfig()
+      .addPlugin(stripTSIgnorePlugin, {})
+      .addPlugin(hoistClassStaticsPlugin, { anyAlias })
+      .addPlugin(reactPropsPlugin, {
+        anyAlias,
+        anyFunctionAlias,
+        shouldUpdateAirbnbImports: true,
+      })
+      .addPlugin(reactClassStatePlugin, { anyAlias })
+      .addPlugin(reactClassLifecycleMethodsPlugin, { force: true })
+      .addPlugin(reactDefaultPropsPlugin, {
+        useDefaultPropsHelper,
+      })
+      .addPlugin(reactShapePlugin, {
+        anyAlias,
+        anyFunctionAlias,
+      })
+      .addPlugin(declareMissingClassPropertiesPlugin, { anyAlias })
+      .addPlugin(memberAccessibilityPlugin, {
+        defaultAccessibility,
+        privateRegex,
+        protectedRegex,
+        publicRegex,
+      })
+      .addPlugin(explicitAnyPlugin, { anyAlias })
+      // We need to run eslint-fix before ts-ignore because formatting may affect where
+      // the errors are that need to get ignored.
+      .addPlugin(eslintFixPlugin, {})
+      .addPlugin(tsIgnorePlugin, {})
+      // We need to run eslint-fix again after ts-ignore to fix up formatting.
+      .addPlugin(eslintFixPlugin, {})
+  );
+}


### PR DESCRIPTION
This PR contains a proposal for a JSON configuration file format for ts-migrate, as well as a basic implementation of the proposal. If the proposal is acceptable, I can write documentation and add further validation to the implementation, if necessary.

I'm completely happy to receive feedback on any level of this proposal. Don't worry about my feelings too much. 😀 

## Context

I see these problems with ts-migrate:

#### It should be easy to run repeatable migrations and it should be easy to tweak plugin configurations to get the desired results.

There is currently limited ability to configure plugins, and doing it purely from the command line can be cumbersome. We can add more command-line flags to increase configurability, but this makes it more cumbersome.

#### It should be possible to control which plugins run and the order in which they run.

Currently the only way to do this is running multiple `ts-migrate migrate --plugin $plugin` commands.

#### There should be a way to load custom or third-party plugins.

See #41. This proposal **does not aim to solve this problem**, but it's a step towards solving the problem.

## Solution

I propose adding a JSON configuration format for ts-migrate that allows specifying which plugins run, in what order, and the options passed to them.

The `migrate` command has a new flag, `--config/-c`, which specifies the path to the configuration file. If a configuration file is specified, other flags are ignored.

The top-level configuration object has two properties:

* `plugins` - a JSON array of plugins to run. Each plugin is a JSON object, described below.
* `globalOptions` (optional) - a JSON object of options which are passed to all plugins. Typically this is where `anyAlias` and `anyFunctionAlias` would be defined, but technically any option may be defined here.

A plugin object has two properties:

* `name`: The name of the plugin. For example, `strip-ts-ignore`.
* `options` (optional): The options to be passed to the plugin. Options specified here override `globalOptions`.

## Downsides

* Plugins may have to be more defensive about validating the options that come in, since they may come from a configuration file which is not type-checked.
* Plugins must use JSON-compatible values for their options. (All plugins currently do.)
* Currently the `reignore` command cannot be expressed in terms of a configuration object due to the "higher-order" plugins it uses. (`withChangeTracking`, `eslintFixChangedPlugin`)

## Schema

Here is a basic JSON schema which describes the structure of the configuration object. See also the defined TypeScript types in the implementation.

```json
{
  "title": "Config",
  "type": "object",
  "required": ["plugins"],
  "properties": {
    "globalOptions": {
      "type": "object"
    },
    "plugins": {
      "title": "Plugin",
      "type": "array",
      "items": {
        "type": "object",
        "required": ["name"],
        "properties": {
          "name": {
            "type": "string"
          },
          "options": {
            "type": "object"
          }
        }
      }
    }
  }
}
```

## Example

The configuration for the default `migrate` command would look like this:

```json
{
  "globalOptions": {
    "//": "When --aliases tsfixme is passed",
    "anyAlias": "$TSFixMe",
    "anyFunctionAlias": "$TSFixMeFunction"
  },
  "plugins": [
    {
      "name": "strip-ts-ignore"
    },
    {
      "name": "hoist-class-statics"
    },
    {
      "name": "react-props",
      "options": {
        "shouldUpdateAirbnbImports": true
      }
    },
    {
      "name": "react-class-state"
    },
    {
      "name": "react-class-lifecycle-methods",
      "options": {
        "force": true
      }
    },
    {
      "name": "react-default-props",
      "options": {
        "//": "When --use-default-props-helper is passed",
        "useDefaultPropsHelper": true
      }
    },
    {
      "name": "react-shape-plugin"
    },
    {
      "name": "declare-missing-class-properties"
    },
    {
      "name": "explicit-any"
    },
    {
      "name": "eslint-fix"
    },
    {
      "name": "ts-ignore"
    },
    {
      "name": "eslint-fix"
    }
  ]
}
```