### PR TITLE
New plugin: add-conversions

### DIFF
--- a/packages/ts-migrate-plugins/README.md
+++ b/packages/ts-migrate-plugins/README.md
@@ -40,6 +40,7 @@ process.exit(exitCode);
 
 | Name | Description |
 | ---- | ----------- |
+| [add-conversions](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/add-conversions.ts) | Add conversions to `any` (`$TSFixMe`) in the case of type errors. |
 | [declare-missing-class-properties](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts) | Declare missing class properties. |
 | [eslint-fix](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/eslint-fix.ts) | Run eslint fix to fix any eslint violations that happened along the way. |
 | [explicit-any](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-plugins/src/plugins/explicit-any.ts) | Annotate variables with `any` (`$TSFixMe`) in the case of an implicit any violation. |

--- a/packages/ts-migrate-plugins/src/index.ts
+++ b/packages/ts-migrate-plugins/src/index.ts
@@ -1,4 +1,5 @@
 import { Plugin as PluginType } from 'ts-migrate-server';
+import addConversionsPlugin from './plugins/add-conversions';
 import declareMissingClassPropertiesPlugin from './plugins/declare-missing-class-properties';
 import eslintFixPlugin from './plugins/eslint-fix';
 import explicitAnyPlugin from './plugins/explicit-any';
@@ -20,6 +21,7 @@ export type Plugin<T = unknown> = PluginType<T>;
 export type SourceTextUpdate = SourceTextUpdateType;
 
 export {
+  addConversionsPlugin,
   declareMissingClassPropertiesPlugin,
   eslintFixPlugin,
   explicitAnyPlugin,

--- a/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
+++ b/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
@@ -1,0 +1,66 @@
+import ts from 'typescript';
+import { Plugin } from 'ts-migrate-server';
+import { isDiagnosticWithLinePosition } from '../utils/type-guards';
+import getTokenAtPosition from './utils/token-pos';
+
+type Options = {
+  anyAlias?: string;
+};
+
+const addConversionsPlugin: Plugin<Options> = {
+  name: 'add-conversions',
+  run({ fileName, sourceFile, text, options, getLanguageService }) {
+    // Filter out TS2339: Property '{0}' does not exist on type '{1}'.
+    const diags = getLanguageService()
+      .getSemanticDiagnostics(fileName)
+      .filter(isDiagnosticWithLinePosition)
+      .filter((diag) => diag.code === 2339);
+
+    const result = ts.transform(sourceFile, [addConversionsTransformerFactory(diags, options)]);
+    const newSourceFile = result.transformed[0];
+    if (newSourceFile === sourceFile) {
+      return text;
+    }
+    const printer = ts.createPrinter();
+    return printer.printFile(newSourceFile);
+  },
+};
+
+export default addConversionsPlugin;
+
+const addConversionsTransformerFactory = (
+  diags: ts.DiagnosticWithLocation[],
+  { anyAlias }: Options,
+) => (context: ts.TransformationContext) => {
+  const { factory } = context;
+  const anyType = anyAlias
+    ? factory.createTypeReferenceNode(anyAlias)
+    : factory.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+
+  let nodesToConvert: Set<ts.Node>;
+
+  return (file: ts.SourceFile) => {
+    nodesToConvert = new Set(
+      diags
+        .map((diag) => {
+          const token = getTokenAtPosition(file, diag.start);
+          if (!ts.isPropertyAccessExpression(token.parent)) {
+            return null;
+          }
+          return token.parent.expression;
+        })
+        .filter((node): node is ts.LeftHandSideExpression => node !== null),
+    );
+    return ts.visitNode(file, visit);
+  };
+
+  function visit(origNode: ts.Node): ts.Node {
+    const needsConversion = nodesToConvert.has(origNode);
+    const node = ts.visitEachChild(origNode, visit, context);
+    if (!needsConversion) {
+      return node;
+    }
+
+    return factory.createAsExpression(node as ts.Expression, anyType);
+  }
+};

--- a/packages/ts-migrate-plugins/src/plugins/utils/token-pos.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/token-pos.ts
@@ -1,0 +1,33 @@
+import ts from 'typescript';
+
+/**
+ * Returns the token whose text contains the position.
+ * If the position is past the end of the file, then it returns the file node itself.
+ *
+ * This function is adapted from TypeScript:
+ * https://github.com/microsoft/TypeScript/blob/v4.1.3/src/services/utilities.ts#L1095
+ */
+export default function getTokenAtPosition(sourceFile: ts.SourceFile, position: number): ts.Node {
+  let current: ts.Node = sourceFile;
+  // eslint-disable-next-line no-restricted-syntax, no-labels
+  outer: while (true) {
+    // find the child that contains 'position'
+    // eslint-disable-next-line no-restricted-syntax
+    for (const child of current.getChildren(sourceFile)) {
+      const start = child.getFullStart();
+      if (start > position) {
+        // If this child begins after position, then all subsequent children will as well.
+        break;
+      }
+
+      const end = child.getEnd();
+      if (position < end || (position === end && child.kind === ts.SyntaxKind.EndOfFileToken)) {
+        current = child;
+        // eslint-disable-next-line no-continue, no-labels
+        continue outer;
+      }
+    }
+
+    return current;
+  }
+}

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -1,0 +1,32 @@
+import { realPluginParams } from '../test-utils';
+import addConversionsPlugin from '../../src/plugins/add-conversions';
+
+describe('add-conversions plugin', () => {
+  const text = `\
+const a = {};
+a.b = 1;
+console.log(a.c);
+`;
+
+  it('adds conversions', async () => {
+    const result = addConversionsPlugin.run(await realPluginParams({ text }));
+
+    expect(result).toBe(`\
+const a = {};
+(a as any).b = 1;
+console.log((a as any).c);
+`);
+  });
+
+  it('adds conversions with alias', async () => {
+    const result = addConversionsPlugin.run(
+      await realPluginParams({ text, options: { anyAlias: '$TSFixMe' } }),
+    );
+
+    expect(result).toBe(`\
+const a = {};
+(a as $TSFixMe).b = 1;
+console.log((a as $TSFixMe).c);
+`);
+  });
+});

--- a/packages/ts-migrate-plugins/tests/src/utils/token-pos.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/utils/token-pos.test.ts
@@ -1,0 +1,26 @@
+import ts from 'typescript';
+import getTokenAtPosition from '../../../src/plugins/utils/token-pos';
+
+describe('getTokenAtPos', () => {
+  it('returns the token at a position', () => {
+    const text = `\
+const c = 1;
+`;
+    const file = ts.createSourceFile('file.ts', text, ts.ScriptTarget.Latest);
+
+    const expectToken = (position: number, kind: ts.SyntaxKind) => {
+      expect(getTokenAtPosition(file, position)).toMatchObject({ kind });
+    };
+
+    expectToken(0, ts.SyntaxKind.ConstKeyword);
+    expectToken(4, ts.SyntaxKind.ConstKeyword);
+    expect(getTokenAtPosition(file, 5)).toMatchObject({
+      kind: ts.SyntaxKind.Identifier,
+      escapedText: 'c',
+    });
+    expectToken(7, ts.SyntaxKind.EqualsToken);
+    expectToken(text.length - 1, ts.SyntaxKind.EndOfFileToken);
+    expectToken(text.length, ts.SyntaxKind.EndOfFileToken);
+    expect(getTokenAtPosition(file, text.length + 1)).toBe(file);
+  });
+});

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -6,6 +6,7 @@ import log from 'updatable-log';
 import yargs from 'yargs';
 
 import {
+  addConversionsPlugin,
   declareMissingClassPropertiesPlugin,
   eslintFixPlugin,
   explicitAnyPlugin,
@@ -97,6 +98,7 @@ yargs
 
       if (args.plugin) {
         const availablePlugins = [
+          addConversionsPlugin,
           declareMissingClassPropertiesPlugin,
           eslintFixPlugin,
           explicitAnyPlugin,
@@ -159,6 +161,7 @@ yargs
             publicRegex,
           })
           .addPlugin(explicitAnyPlugin, { anyAlias })
+          .addPlugin(addConversionsPlugin, { anyAlias })
           // We need to run eslint-fix before ts-ignore because formatting may affect where
           // the errors are that need to get ignored.
           .addPlugin(eslintFixPlugin, {})


### PR DESCRIPTION
This pull request introduces a new plugin, `add-conversions`, which adds conversions to `any` (`$TSFixMe`) in order to silence type errors.

This plugin runs as part of the `migrate` command.

## Why?

When migrating to TypeScript, the vast majority of errors I experienced were `TS2339: Property '{0}' does not exist on type '{1}'`.

These get fixed with the `ts-ignore` plugin, but `ts-ignore` should be a very last resort to fixing errors. In this case there's a better option available: add a conversion to `any` (or the appropriate `any` alias).

This is better because it is less whitespace-sensitive and silences exactly one error. (`ts-ignore`/`ts-expect-error` silence errors for an entire line, which can contain multiple errors.)

With an `any` alias such as `$TSFixMe`, the conversions are still ugly, searchable, and be addressed properly later.