### PR TITLE
Handle implicit any errors for rest parameters

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
+++ b/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
@@ -35,6 +35,11 @@ function withExplicitAny(
     diagnostics.filter((diagnostic) => diagnostic.code === 7006),
     typeAnnotation,
   );
+  replaceTS7019(
+    root,
+    diagnostics.filter((diagnostic) => diagnostic.code === 7019),
+    j.tsTypeAnnotation(j.tsArrayType(anyType)),
+  );
   replaceTS7031(
     root,
     diagnostics.filter((diagnostic) => diagnostic.code === 7031),
@@ -96,6 +101,27 @@ function replaceTS7006(
         } else {
           path.get('typeAnnotation').replace(typeAnnotation);
         }
+      });
+  });
+}
+
+// TS7019: "Rest parameter '{0}' implicitly has an 'any[]' type."
+function replaceTS7019(
+  root: Collection<any>,
+  diagnostics: ts.DiagnosticWithLocation[],
+  typeAnnotation: TSTypeAnnotation,
+) {
+  diagnostics.forEach((diagnostic) => {
+    root
+      .find(
+        j.RestElement,
+        (node: any) =>
+          node.start === diagnostic.start &&
+          node.end === diagnostic.start + diagnostic.length &&
+          node.typeAnnotation == null,
+      )
+      .forEach((path) => {
+        path.get('typeAnnotation').replace(typeAnnotation);
       });
   });
 }

--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -16,6 +16,8 @@ function f3() {
   return var1;
 }
 function fn4({ arg4: { arg5, arg_6: arg6 } }) {}
+function fn5(...rest) {}
+const fn6 = (...rest) => {}
 const {
   root_see_all_link_text: rootSeeAllLinkText,
   root_subtitle: rootSubtitle,
@@ -57,6 +59,8 @@ function f3() {
 function fn4({
   arg4: { arg5, arg_6: arg6 }
 }: any) {}
+function fn5(...rest: any[]) {}
+const fn6 = (...rest: any[]) => {}
 const {
   root_see_all_link_text: rootSeeAllLinkText,
   root_subtitle: rootSubtitle,


### PR DESCRIPTION
This PR extends the `explicit-any` plugin to be able to handle `TS7019`, which occurs when a rest parameter has no type annotation. The plugin adds an explicit annotation `: any[]` (or using the alias, if specified).