### PR TITLE
Handle implicit any errors on 'this'

### DIFF
--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -84,6 +84,26 @@ const {
 `);
   });
 
+  it('adds explicit any to this', async () => {
+    const text = `\
+function f1(a: any) { return this; }
+const f2 = function() { return this; }
+function f3() { return () => this; }
+`;
+
+    const result = await explicitAnyPlugin.run(
+      await realPluginParams({
+        text,
+      }),
+    );
+
+    expect(result).toBe(`\
+function f1(this: any, a: any) { return this; }
+const f2 = function(this: any) { return this; }
+function f3(this: any) { return () => this; }
+`);
+  });
+
   it('adds explicit any with alias', async () => {
     const text = `const var1 = [];`;
 


### PR DESCRIPTION
This PR extends the `explicit-any` plugin to be able to handle `TS2683`, which occurs when a non-arrow, non-method function references `this` without a type annotation. The plugin adds an explicit annotation `this: any` (or using the alias, if specified), which appears before any existing parameters.