### PR TITLE
Add conversions to values with unknown type

### DIFF
--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -29,4 +29,20 @@ const a = {};
 console.log((a as $TSFixMe).c);
 `);
   });
+
+  it('adds conversions to unknown types', async () => {
+    const text = `\
+function f(u: unknown) {
+    console.log(u.prop);
+}
+`;
+
+    const result = addConversionsPlugin.run(await realPluginParams({ text }));
+
+    expect(result).toBe(`\
+function f(u: unknown) {
+    console.log((u as any).prop);
+}
+`);
+  });
 });


### PR DESCRIPTION
Extends the add-conversions plugin to handle `TS2571: Object is of type 'unknown'`.