### PR TITLE
Fix react-props for arrow function components with no parentheses

### DIFF
--- a/packages/ts-migrate-plugins/tests/src/react-props.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/react-props.test.ts
@@ -1219,4 +1219,27 @@ export default class PaymentPlanOptionExplanation extends React.PureComponent<Pr
 }
 `);
   });
+
+  it('handles single-parameter arrow functions with no parentheses', async () => {
+    const text = `\
+const InfoPanel = props => {
+  return null;
+};
+
+InfoPanel.propTypes = {
+  foo: PropTypes.bool,
+};
+`;
+
+    const result = await reactPropsPlugin.run(mockPluginParams({ text, fileName: 'Foo.tsx' }));
+
+    expect(result).toBe(`
+
+type Props = {
+    foo?: boolean;
+};const InfoPanel =(props: Props) => {
+  return null;
+};
+`);
+  });
 });


### PR DESCRIPTION
Prior to this fix, no parentheses were added to single-parameter arrow functions. So this:

```
const Component = props => null;
```

became:

```
const Component = props: Props => null;
```

...which is invalid syntax!

Fixes #62.