### PR TITLE
fix ts-migrate-full npx command

### DIFF
--- a/packages/ts-migrate/README.md
+++ b/packages/ts-migrate/README.md
@@ -21,7 +21,7 @@ Or [yarn](https://yarnpkg.com):
 Migrate an entire project like this:
 
 ```sh
-npx ts-migrate-full <folder>
+npx -p ts-migrate -c "ts-migrate-full <folder>"
 ```
 
 Please note that it may take a long time to do a full migration.


### PR DESCRIPTION
Doing `npx ts-migrate-full` attempts to install the package `ts-migrate-full` (which doesn't exist). This new version will work.

Not sure how to fix the longer example below though... I'm not sure how to do multiple lines with the `-c` in quotes.