### PR TITLE
Filter out node_modules

### DIFF
--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -60,7 +60,7 @@ export default async function migrate({
 
     const sourceFiles = project
       .getSourceFiles()
-      .filter(({ fileName }) => !/(\.d\.ts|\.json)$/.test(fileName));
+      .filter(({ fileName }) => !/(\.d\.ts|\.json)$|node_modules/.test(fileName));
 
     // eslint-disable-next-line no-restricted-syntax
     for (const sourceFile of sourceFiles) {


### PR DESCRIPTION
Partially addresses #95.

In my project, when I run `reignore` and then `tsc`, I get 136 type errors. With this change, the type errors are cut down to 74.

The problem is that I'm operating on a monorepo, which has a traditional structure:

```
packages/
  foo/
    index.js
node_modules/
  foo -> ../packages/foo
```

`project.getSourceFiles()` was returning `['packages/foo/index.js', 'node_modules/foo/index.js']`. `getSemanticDiagnostics()` had results for the `node_modules` entry but not the `packages` entry. 

I don't have time to add tests. "Mother forgive me."