### PR TITLE
Give consistent sources to each plugin when migrating

### DIFF
--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -50,6 +50,9 @@ export default async function migrate({
   log.info('Start...');
   const pluginsTimer = new PerfTimer();
   const updatedSourceFiles = new Set<string>();
+  const sourceFiles = project
+    .getSourceFiles()
+    .filter(({ fileName }) => !/(\.d\.ts|\.json)$|node_modules/.test(fileName));
 
   for (let i = 0; i < config.plugins.length; i += 1) {
     const { plugin, options: pluginOptions } = config.plugins[i];
@@ -57,10 +60,6 @@ export default async function migrate({
     const pluginLogPrefix = `[${plugin.name}]`;
     const pluginTimer = new PerfTimer();
     log.info(`${pluginLogPrefix} Plugin ${i + 1} of ${config.plugins.length}. Start...`);
-
-    const sourceFiles = project
-      .getSourceFiles()
-      .filter(({ fileName }) => !/(\.d\.ts|\.json)$|node_modules/.test(fileName));
 
     // eslint-disable-next-line no-restricted-syntax
     for (const sourceFile of sourceFiles) {


### PR DESCRIPTION
Hey there! 

I have a small pull request. In short: collect source files once and share them with all plugins, instead of collecting them before every plugin. This feels like the sort of change that I might need some context around, but tests pass and things generally seem to work with this change applied.

## The problem

Currently, the list of sources in a project is recalculated after each plugin is run. Some plugins, like `explicitAny` and declareMissingClassProperties`, seem to expand the scope of a project by pulling dependencies of the file they're modifying into the project. This means that the order in which plugins run impacts which files ts-migrate modifies. It also means that if you're using the `--sources` flag, files outside the scope of your sources end up having some codemods unexpectedly run on them.

## This patch

This change finds sources for a project once, before any plugins are run, and re-uses them for each plugin. (I literally just moved the declaration of `sourceFiles` out of the plugin loop). If a plugin pulls more files into a project, the new files won't be passed to other plugins down the line. 

## Testing

- `yarn test` and `yarn lint` seem happy
- Passing a directory to `migrate()` with `--sources` previously modified files outside that directory; this no longer happens.