### PR TITLE
Revert #99

### DIFF
--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -50,9 +50,6 @@ export default async function migrate({
   log.info('Start...');
   const pluginsTimer = new PerfTimer();
   const updatedSourceFiles = new Set<string>();
-  const sourceFiles = project
-    .getSourceFiles()
-    .filter(({ fileName }) => !/(\.d\.ts|\.json)$|node_modules/.test(fileName));
 
   for (let i = 0; i < config.plugins.length; i += 1) {
     const { plugin, options: pluginOptions } = config.plugins[i];
@@ -60,6 +57,10 @@ export default async function migrate({
     const pluginLogPrefix = `[${plugin.name}]`;
     const pluginTimer = new PerfTimer();
     log.info(`${pluginLogPrefix} Plugin ${i + 1} of ${config.plugins.length}. Start...`);
+
+    const sourceFiles = project
+      .getSourceFiles()
+      .filter(({ fileName }) => !/(\.d\.ts|\.json)$|node_modules/.test(fileName));
 
     // eslint-disable-next-line no-restricted-syntax
     for (const sourceFile of sourceFiles) {

--- a/packages/ts-migrate-server/tests/commands/migrate/migrate.test.ts
+++ b/packages/ts-migrate-server/tests/commands/migrate/migrate.test.ts
@@ -44,4 +44,41 @@ describe('migrate command', () => {
     expect(rootData).toEqual(outputData);
     expect(exitCode).toBe(0);
   });
+
+  it('Migrates project with two plugins', async () => {
+    const inputDir = path.resolve(__dirname, 'input');
+    const outputDir = path.resolve(__dirname, 'output_two');
+    const configDir = path.resolve(__dirname, 'config');
+
+    copyDir(inputDir, rootDir);
+    copyDir(configDir, rootDir);
+
+    const config = new MigrateConfig()
+      .addPlugin(
+        {
+          name: 'test-plugin-1',
+          run({ text }) {
+            const newText = text.replace('test string', 'updated string');
+            return newText;
+          },
+        },
+        {},
+      )
+      .addPlugin(
+        {
+          name: 'test-plugin-2',
+          run({ text }) {
+            const newText = text.replace('updated string', 'another updated string');
+            return newText;
+          },
+        },
+        {},
+      );
+
+    const exitCode = await migrate({ rootDir, config });
+    fs.unlinkSync(path.resolve(rootDir, 'tsconfig.json'));
+    const [rootData, outputData] = getDirData(rootDir, outputDir);
+    expect(rootData).toEqual(outputData);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/packages/ts-migrate-server/tests/commands/migrate/output_two/index.ts
+++ b/packages/ts-migrate-server/tests/commands/migrate/output_two/index.ts
@@ -1,0 +1,1 @@
+console.log('another updated string');


### PR DESCRIPTION
This reverts #99, which introduced a regression that caused the output of one plugin to not be passed as the input to another plugin.

The call to `updateSourceFile` creates a new source file underneath, but we only reference the original. This means that each plugin receives the original source text and never receives the output of other plugins. The last plugin to write to a particular file "wins".

This PR also includes a test case that fails when #99 is applied, but passes again after the revert.

cc @salemhilal, who authored #99. I would still like to understand the bug that it aimed to fix and discuss whether there might be another way we can approach it. It would be good to start with a failing test case and work forward from there.

Fixes #104.