### PR TITLE
Handle TS7008 in the explicit-any plugin

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
+++ b/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
@@ -35,9 +35,9 @@ function withExplicitAny(
     diagnostics.filter((diagnostic) => diagnostic.code === 2683),
     typeAnnotation,
   );
-  replaceTS7006(
+  replaceTS7006AndTS7008(
     root,
-    diagnostics.filter((diagnostic) => diagnostic.code === 7006),
+    diagnostics.filter((diagnostic) => diagnostic.code === 7006 || diagnostic.code === 7008),
     typeAnnotation,
   );
   replaceTS7019(
@@ -97,7 +97,8 @@ function replaceTS2683(
 }
 
 // TS7006: "Parameter '{0}' implicitly has an '{1}' type."
-function replaceTS7006(
+// TS7008: "Member '{0}' implicitly has an '{1}' type."
+function replaceTS7006AndTS7008(
   root: Collection<any>,
   diagnostics: ts.DiagnosticWithLocation[],
   typeAnnotation: TSTypeAnnotation,

--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -18,6 +18,7 @@ function f3() {
 function fn4({ arg4: { arg5, arg_6: arg6 } }) {}
 function fn5(...rest) {}
 const fn6 = (...rest) => {}
+const fn7 = ({ id }: { id }) => {}
 const {
   root_see_all_link_text: rootSeeAllLinkText,
   root_subtitle: rootSubtitle,
@@ -61,6 +62,7 @@ function fn4({
 }: any) {}
 function fn5(...rest: any[]) {}
 const fn6 = (...rest: any[]) => {}
+const fn7 = ({ id }: { id: any }) => {}
 const {
   root_see_all_link_text: rootSeeAllLinkText,
   root_subtitle: rootSubtitle,


### PR DESCRIPTION
TS7008 can be handled by the TS7006 code as well so I've simply renamed that function and expanded the condition under which it's called.

Fixes #88.