### PR TITLE
Test against Node 16; drop Node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: ['10', '12', '14']
+        node-version: ['12', '14', '16']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^26.0.9",
     "@types/jscodeshift": "^0.11.0",
     "@types/json5": "0.0.30",
-    "@types/node": "^9.6.55",
+    "@types/node": "^12.20.10",
     "@types/react": "^16.9.16",
     "@types/rimraf": "^2.0.3",
     "@types/yargs": "^13.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2708,10 +2708,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.27.tgz#a151873af5a5e851b51b3b065c9e63390a9e0eb1"
   integrity sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g==
 
-"@types/node@^9.6.55":
-  version "9.6.57"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-9.6.57.tgz#ff4c4ffab747783c0c2ba2e2c20e670da2cbee8d"
-  integrity sha512-588MBlPWKeJFshLmnYbqMEaM3NaJFCVZFgpQ5rQxKCVXMNw2Gs7sTORvCDlaPBP6AabiIvmd22eT9fcIvTeZUw==
+"@types/node@^12.20.10":
+  version "12.20.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.10.tgz#4dcb8a85a8f1211acafb88d72fafc7e3d2685583"
+  integrity sha512-TxCmnSSppKBBOzYzPR2BR25YlX5Oay8z2XGwFBInuA/Co0V9xJhLlW4kjbxKtgeNo3NOMbQP1A5Rc03y+XecPw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"


### PR DESCRIPTION
Node 16 has been released and Node 10 hits end of life in a few days, so I'm removing Node 10 from CI and adding Node 16.

Also bumping `@types/node` to 12 to match up with the minimum supported Node version.