### PR TITLE
Work around jscodeshift arrow function bug

### DIFF
--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -122,4 +122,16 @@ function f3(this: any) { return () => this; }
 
     expect(result).toBe(`const var1: $TSFixMe = [];`);
   });
+
+  it('handles arrow functions returning object literals', async () => {
+    const text = `const fn = (b) => ({});`;
+
+    const result = await explicitAnyPlugin.run(
+      await realPluginParams({
+        text,
+      }),
+    );
+
+    expect(result).toBe(`const fn = (b: any) => ({});`);
+  });
 });


### PR DESCRIPTION
recast, a jscodeshift dependency, has an issue (https://github.com/benjamn/recast/issues/743) where re-printed arrow functions returning object literals do not include surrounding parentheses, which means that code gets transformed in an invalid way. (`() => {}` instead of `() => ({})`.)

We can work around this issue by re-creating the object literal node, similar to an existing arrow function workaround.

Fixes #113.