### PR TITLE
explicit-any: Prevent adding this multiple times

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
+++ b/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
@@ -74,6 +74,8 @@ function replaceTS2683(
   diagnostics: ts.DiagnosticWithLocation[],
   typeAnnotation: TSTypeAnnotation,
 ) {
+  const annotated = new Set();
+
   diagnostics.forEach((diagnostic) => {
     root
       .find(
@@ -91,7 +93,12 @@ function replaceTS2683(
         ) {
           newNode = newNode.parentPath;
         }
-        newNode.get('params').unshift(j.identifier.from({ name: 'this', typeAnnotation }));
+
+        // Add annotation only if we haven't already added one to this function.
+        if (!annotated.has(newNode)) {
+          newNode.get('params').unshift(j.identifier.from({ name: 'this', typeAnnotation }));
+          annotated.add(newNode);
+        }
       });
   });
 }

--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -91,6 +91,7 @@ const {
 function f1(a: any) { return this; }
 const f2 = function() { return this; }
 function f3() { return () => this; }
+function f4() { this.a = 1; this.b = 2; }
 `;
 
     const result = await explicitAnyPlugin.run(
@@ -103,6 +104,7 @@ function f3() { return () => this; }
 function f1(this: any, a: any) { return this; }
 const f2 = function(this: any) { return this; }
 function f3(this: any) { return () => this; }
+function f4(this: any) { this.a = 1; this.b = 2; }
 `);
   });
 


### PR DESCRIPTION
The explicit-any plugin had a bug where `this: any` could be prepended multiple times to the list of parameters if `this` was referenced more than once.

I've solved the issue by keeping a `Set` that tracks function nodes which are already annotated.