### PR TITLE
Stablizes transforms of class property arrow functions

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
+++ b/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
@@ -168,6 +168,7 @@ function shouldReplace(node: ts.Node): boolean {
     case ts.SyntaxKind.ClassDeclaration:
     case ts.SyntaxKind.EnumMember:
     case ts.SyntaxKind.HeritageClause:
+    case ts.SyntaxKind.PropertyDeclaration:
     case ts.SyntaxKind.SourceFile: // In case we missed any other case.
       return true;
     default:

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -90,4 +90,27 @@ function f(u: unknown) {
 }
 `);
   });
+
+  it('replaces only the necessary code in class property arrow functions (issue #134)', async () => {
+    const text = `\
+class PublishEvent {
+  constructor(opts = {}) {
+    this._eventName = opts.eventName;
+  }
+
+  addEventListener = () => document.addEventListener(this._eventName, this.publish);
+}
+`;
+    const result = addConversionsPlugin.run(await realPluginParams({ text }));
+
+    expect(result).toBe(`\
+class PublishEvent {
+  constructor(opts = {}) {
+    (this as any)._eventName = (opts as any).eventName;
+  }
+
+  addEventListener = () => document.addEventListener((this as any)._eventName, (this as any).publish);
+}
+`);
+  });
 });


### PR DESCRIPTION
Closes #134, an issue I ran into when trying to migrate multiple repos that resulted in broken code in certain files.

I am not entirely sure if this is the best way to make the fix, so any pointers there would be appreciated. The fix is working for a minimal test case (in the test suite) as well as on my code base leaving the syntax in place and removing 15 of 392 `@ts-expect-error`s.

I have seen cases where white space can get messed up as mentioned in the comment for `shouldReplace`.

Willing to work towards a different solution is there is a better one.