### PR TITLE
Proposal: Update packages to use typescript as peer dependency

### DIFF
--- a/packages/ts-migrate-example/package.json
+++ b/packages/ts-migrate-example/package.json
@@ -11,7 +11,9 @@
     "jscodeshift": "^0.12.0",
     "ts-migrate-plugins": "^0.1.23",
     "ts-migrate-server": "^0.1.23",
-    "ts-node": "^8.3.0",
-    "typescript": "4.2.4"
+    "ts-node": "^8.3.0"
+  },
+  "peerDependencies": {
+    "typescript": ">4.0"
   }
 }

--- a/packages/ts-migrate-plugins/package.json
+++ b/packages/ts-migrate-plugins/package.json
@@ -62,13 +62,15 @@
     "eslint": "^7.14.0",
     "jscodeshift": "^0.13.0",
     "json-schema": "^0.3.0",
-    "ts-migrate-server": "^0.1.23",
-    "typescript": "4.2.4"
+    "ts-migrate-server": "^0.1.23"
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",
   "devDependencies": {
     "@ts-morph/bootstrap": "^0.9.1",
     "@types/json-schema": "^7.0.7",
     "jest": "26.6.3"
+  },
+  "peerDependencies": {
+    "typescript": ">4.0"
   }
 }

--- a/packages/ts-migrate-server/package.json
+++ b/packages/ts-migrate-server/package.json
@@ -61,8 +61,10 @@
   "dependencies": {
     "@ts-morph/bootstrap": "^0.9.1",
     "pretty-ms": "^7.0.1",
-    "typescript": "4.2.4",
     "updatable-log": "^0.2.0"
   },
-  "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3"
+  "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",
+  "peerDependencies": {
+    "typescript": ">4.0"
+  }
 }

--- a/packages/ts-migrate/package.json
+++ b/packages/ts-migrate/package.json
@@ -67,7 +67,6 @@
     "json5-writer": "^0.1.8",
     "ts-migrate-plugins": "^0.1.23",
     "ts-migrate-server": "^0.1.23",
-    "typescript": "4.2.4",
     "updatable-log": "^0.2.0",
     "yargs": "^15.0.2"
   },
@@ -77,5 +76,8 @@
     "jest": "26.6.3",
     "react": "^16.12.0"
   },
-  "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3"
+  "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",
+  "peerDependencies": {
+    "typescript": ">4.0"
+  }
 }


### PR DESCRIPTION
### Context
Packages currently have a hard coded typescript dependency (v4.2.4). This can lead to issues due to the typescript version mismatch between the package and project in use. For example, the reignore script can result in false negatives (and probably false positives); v4.2.4 reignore doesn't catch all ts-ignores on projects running 4.4.3+

### Solution
This PR removes the hardcoded typescript dependency from packages and adds it as a peer dependency. The version is set to `>4.0` which is when ts introdued a new node factory API. [See related issue](https://github.com/airbnb/ts-migrate/issues/87).