### PR TITLE
Document --plugin CLI option

### DIFF
--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -26,6 +26,23 @@ import { migrate, MigrateConfig } from 'ts-migrate-server';
 import init from './commands/init';
 import rename from './commands/rename';
 
+const availablePlugins = [
+  addConversionsPlugin,
+  declareMissingClassPropertiesPlugin,
+  eslintFixPlugin,
+  explicitAnyPlugin,
+  hoistClassStaticsPlugin,
+  jsDocPlugin,
+  memberAccessibilityPlugin,
+  reactClassLifecycleMethodsPlugin,
+  reactClassStatePlugin,
+  reactDefaultPropsPlugin,
+  reactPropsPlugin,
+  reactShapePlugin,
+  stripTSIgnorePlugin,
+  tsIgnorePlugin,
+];
+
 // eslint-disable-next-line no-unused-expressions
 yargs
   .scriptName('npm run ts-migrate --')
@@ -79,6 +96,8 @@ yargs
         .positional('folder', { type: 'string' })
         .choices('defaultAccessibility', ['private', 'protected', 'public'] as const)
         .string('plugin')
+        .choices('plugin', availablePlugins.map((p) => p.name))
+        .describe('plugin', 'Run a specific plugin')
         .string('privateRegex')
         .string('protectedRegex')
         .string('publicRegex')
@@ -90,6 +109,7 @@ yargs
           '$0 migrate /frontend/foo -s "bar/**/*" -s "node_modules/**/*.d.ts"',
           'Migrate all the files in /frontend/foo/bar, accounting for ambient types from node_modules.',
         )
+        .example('$0 migrate /frontend/foo --plugin jsdoc', 'Migrate JSDoc comments for all the files in /frontend/foo')
         .require(['folder']),
     async (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);
@@ -97,22 +117,6 @@ yargs
       let config: MigrateConfig;
 
       if (args.plugin) {
-        const availablePlugins = [
-          addConversionsPlugin,
-          declareMissingClassPropertiesPlugin,
-          eslintFixPlugin,
-          explicitAnyPlugin,
-          hoistClassStaticsPlugin,
-          jsDocPlugin,
-          memberAccessibilityPlugin,
-          reactClassLifecycleMethodsPlugin,
-          reactClassStatePlugin,
-          reactDefaultPropsPlugin,
-          reactPropsPlugin,
-          reactShapePlugin,
-          stripTSIgnorePlugin,
-          tsIgnorePlugin,
-        ];
         const plugin = availablePlugins.find((cur) => cur.name === args.plugin);
         if (!plugin) {
           log.error(`Could not find a plugin named ${args.plugin}.`);

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -96,7 +96,10 @@ yargs
         .positional('folder', { type: 'string' })
         .choices('defaultAccessibility', ['private', 'protected', 'public'] as const)
         .string('plugin')
-        .choices('plugin', availablePlugins.map((p) => p.name))
+        .choices(
+          'plugin',
+          availablePlugins.map((p) => p.name),
+        )
         .describe('plugin', 'Run a specific plugin')
         .string('privateRegex')
         .string('protectedRegex')
@@ -109,7 +112,10 @@ yargs
           '$0 migrate /frontend/foo -s "bar/**/*" -s "node_modules/**/*.d.ts"',
           'Migrate all the files in /frontend/foo/bar, accounting for ambient types from node_modules.',
         )
-        .example('$0 migrate /frontend/foo --plugin jsdoc', 'Migrate JSDoc comments for all the files in /frontend/foo')
+        .example(
+          '$0 migrate /frontend/foo --plugin jsdoc',
+          'Migrate JSDoc comments for all the files in /frontend/foo',
+        )
         .require(['folder']),
     async (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);


### PR DESCRIPTION
Since the JSDoc plugin isn't ran by default, it took awhile for me to learn how to run it, eventually realizing that the CLI takes a `--plugin` option. I think this also touches on #136

<img width="928" alt="CleanShot 2021-10-17 at 17 51 38@2x" src="https://user-images.githubusercontent.com/371943/137646241-9c98cc32-9124-4973-9470-867ce6fcc13a.png">

This also does the validation for you and outputs a friendlier error message:

![CleanShot 2021-10-17 at 17 52 33@2x](https://user-images.githubusercontent.com/371943/137646280-26096d58-eff1-453d-8b24-51d992fcf18c.png)
