### PR TITLE
Add messageLimit option to override TS_IGNORE_MESSAGE_LIMIT

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -5,10 +5,14 @@ import { isDiagnosticWithLinePosition } from '../utils/type-guards';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
 import { createValidate, Properties } from '../utils/validateOptions';
 
-type Options = { useTsIgnore?: boolean };
+type Options = {
+  useTsIgnore?: boolean;
+  messageLimit?: number;
+};
 
 const optionProperties: Properties = {
   useTsIgnore: { type: 'boolean' },
+  messageLimit: { type: 'number' },
 };
 
 const tsIgnorePlugin: Plugin<Options> = {
@@ -50,12 +54,10 @@ function getTextWithIgnores(
       .filter(Boolean);
     const message = messageLines[messageLines.length - 1];
     const errorExpression = options.useTsIgnore ? 'ts-ignore' : `ts-expect-error`;
+    const messageLimit = options.messageLimit ?? TS_IGNORE_MESSAGE_LIMIT;
     const tsIgnoreCommentText = `@${errorExpression} ts-migrate(${code}) FIXME: ${
-      message.length > TS_IGNORE_MESSAGE_LIMIT
-        ? `${message.slice(
-            0,
-            TS_IGNORE_MESSAGE_LIMIT,
-          )}... Remove this comment to see the full error message`
+      message.length > messageLimit
+        ? `${message.slice(0, messageLimit)}... Remove this comment to see the full error message`
         : message
     }`;
     if (!isIgnored[diagnosticLine]) {

--- a/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
@@ -117,6 +117,44 @@ export default Foo;
 comsole.log('Hello');`);
   });
 
+  it('use message limit option to avoid error message truncation', async () => {
+    const text = "comsole.log('Hello');";
+    const result = await tsIgnorePlugin.run(
+      mockPluginParams({
+        text,
+        semanticDiagnostics: [
+          mockDiagnostic(text, 'comsole', {
+            messageText:
+              'This message is long, but should not be translated because of the messageLimit option value',
+          }),
+        ],
+        options: { messageLimit: 100 },
+      }),
+    );
+    expect(result)
+      .toBe(`// @ts-expect-error ts-migrate(123) FIXME: This message is long, but should not be translated because of the messageLimit option value
+comsole.log('Hello');`);
+  });
+
+  it('use message limit option to truncate a error message', async () => {
+    const text = "comsole.log('Hello');";
+    const result = await tsIgnorePlugin.run(
+      mockPluginParams({
+        text,
+        semanticDiagnostics: [
+          mockDiagnostic(text, 'comsole', {
+            messageText:
+              'This message is too long, and should be translated because of the messageLimit option value',
+          }),
+        ],
+        options: { messageLimit: 75 },
+      }),
+    );
+    expect(result)
+      .toBe(`// @ts-expect-error ts-migrate(123) FIXME: This message is too long, and should be translated because of the messageLi... Remove this comment to see the full error message
+comsole.log('Hello');`);
+  });
+
   it('does not add ignore comment for webpackChunkName', async () => {
     const text = `const getComponent = normalizeLoader(() =>
   import(


### PR DESCRIPTION
Adds `messageLimit` option to `ts-ignore` plugin.

There is, currently, no way to have long error messages in ts-migrate comments, because the plugging uses `TS_IGNORE_MESSAGE_LIMIT = 50` constant to crop messages. Adding the `messageLimit` option will help to keep original messages in ts-migrate comments. 