### PR TITLE
Use ts-morph (a compiler API wrapper) instead of typescript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
             {
                 "arrowParens": "always",
                 "bracketSpacing": true,
-                "jsxBracketSameLine": false,
+                "bracketSameLine": false,
                 "printWidth": 100,
                 "proseWrap": "preserve",
                 "requirePragma": false,

--- a/packages/ts-migrate-example/package.json
+++ b/packages/ts-migrate-example/package.json
@@ -11,6 +11,7 @@
     "jscodeshift": "^0.12.0",
     "ts-migrate-plugins": "^0.1.27",
     "ts-migrate-server": "^0.1.27",
+    "ts-morph": "^13.0.3",
     "ts-node": "^8.3.0"
   },
   "peerDependencies": {

--- a/packages/ts-migrate-example/src/example-plugin-ts-morph.ts
+++ b/packages/ts-migrate-example/src/example-plugin-ts-morph.ts
@@ -1,0 +1,30 @@
+import { Plugin } from 'ts-migrate-server';
+
+type Options = { shouldReplaceText?: boolean };
+
+const examplePluginTsMorph: Plugin<Options> = {
+  name: 'example-plugin-ts-morph',
+  async run({ sourceFile }) {
+    // get all function declarations from the source file
+    const functionDeclarations = sourceFile.getFunctions();
+
+    functionDeclarations.forEach((functionDeclaration) => {
+      const name = functionDeclaration.getName();
+
+      // add a jsDoc comment before the function
+      functionDeclaration.addJsDoc({
+        description: `This is the function ${name}`,
+      });
+    });
+
+    sourceFile.formatText({
+      indentSize: 2,
+    });
+
+    sourceFile.saveSync();
+
+    return sourceFile.getFullText();
+  },
+};
+
+export default examplePluginTsMorph;

--- a/packages/ts-migrate-example/src/example-plugin-ts.ts
+++ b/packages/ts-migrate-example/src/example-plugin-ts.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import { updateSourceText, SourceTextUpdate } from 'ts-migrate-plugins';
 
@@ -12,7 +12,9 @@ const examplePluginTs: Plugin<Options> = {
     const printer = ts.createPrinter();
 
     // get all function declarations from the source file
-    const functionDeclarations = sourceFile.statements.filter(ts.isFunctionDeclaration);
+    const functionDeclarations = sourceFile.compilerNode.statements.filter(
+      ts.isFunctionDeclaration,
+    );
 
     functionDeclarations.forEach((functionDeclaration) => {
       const hasTwoParams = functionDeclaration.parameters.length === 2;
@@ -54,7 +56,11 @@ const examplePluginTs: Plugin<Options> = {
         const { end } = functionDeclaration;
 
         // generate a new source text for the function declaration
-        const text = printer.printNode(ts.EmitHint.Unspecified, newFunctionDeclaration, sourceFile);
+        const text = printer.printNode(
+          ts.EmitHint.Unspecified,
+          newFunctionDeclaration,
+          sourceFile.compilerNode,
+        );
 
         updates.push({ kind: 'replace', index: start, length: end - start, text });
       }

--- a/packages/ts-migrate-example/src/index.ts
+++ b/packages/ts-migrate-example/src/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { migrate, MigrateConfig } from 'ts-migrate-server';
 
 import examplePluginTs from './example-plugin-ts';
+import examplePluginTsMorph from './example-plugin-ts-morph';
 import examplePluginText from './example-plugin-text';
 import examplePluginJscodeshift from './example-plugin-jscodeshift';
 
@@ -12,7 +13,8 @@ async function runMigration() {
   const config = new MigrateConfig()
     .addPlugin(examplePluginJscodeshift, {})
     .addPlugin(examplePluginTs, { shouldReplaceText: true })
-    .addPlugin(examplePluginText, {});
+    .addPlugin(examplePluginText, {})
+    .addPlugin(examplePluginTsMorph, {});
 
   const exitCode = await migrate({ rootDir: inputDir, config });
 

--- a/packages/ts-migrate-example/src/input/index.ts
+++ b/packages/ts-migrate-example/src/input/index.ts
@@ -1,3 +1,7 @@
 function mult(first, second) {
     return first * second;
 }
+
+function test() {
+    return 'test';
+}

--- a/packages/ts-migrate-example/src/input/tsconfig.json
+++ b/packages/ts-migrate-example/src/input/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "compilerOptions": {}
+}

--- a/packages/ts-migrate-plugins/package.json
+++ b/packages/ts-migrate-plugins/package.json
@@ -62,11 +62,11 @@
     "eslint": "^7.14.0",
     "jscodeshift": "^0.13.0",
     "json-schema": "^0.4.0",
-    "ts-migrate-server": "^0.1.27"
+    "ts-migrate-server": "^0.1.27",
+    "ts-morph": "^13.0.3"
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",
   "devDependencies": {
-    "@ts-morph/bootstrap": "^0.9.1",
     "@types/json-schema": "^7.0.7",
     "jest": "26.6.3"
   },

--- a/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
+++ b/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import { isDiagnosticWithLinePosition } from '../utils/type-guards';
 import getTokenAtPosition from './utils/token-pos';
@@ -20,12 +20,14 @@ const addConversionsPlugin: Plugin<Options> = {
   run({ fileName, sourceFile, options, getLanguageService }) {
     // Filter out diagnostics we care about.
     const diags = getLanguageService()
-      .getSemanticDiagnostics(fileName)
+      .compilerObject.getSemanticDiagnostics(fileName)
       .filter(isDiagnosticWithLinePosition)
       .filter((diag) => supportedDiagnostics.has(diag.code));
 
-    const updates = new UpdateTracker(sourceFile);
-    ts.transform(sourceFile, [addConversionsTransformerFactory(updates, diags, options)]);
+    const updates = new UpdateTracker(sourceFile.compilerNode);
+    ts.transform(sourceFile.compilerNode, [
+      addConversionsTransformerFactory(updates, diags, options),
+    ]);
     return updates.apply();
   },
 

--- a/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts
+++ b/packages/ts-migrate-plugins/src/plugins/declare-missing-class-properties.ts
@@ -12,7 +12,7 @@ const declareMissingClassPropertiesPlugin: Plugin<Options> = {
 
   async run({ text, fileName, getLanguageService, options }) {
     const diagnostics = getLanguageService()
-      .getSemanticDiagnostics(fileName)
+      .compilerObject.getSemanticDiagnostics(fileName)
       .filter(isDiagnosticWithLinePosition)
       .filter((diagnostic) => diagnostic.code === 2339 || diagnostic.code === 2551);
 

--- a/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
+++ b/packages/ts-migrate-plugins/src/plugins/explicit-any.ts
@@ -1,6 +1,6 @@
 import jscodeshift, { Identifier, TSTypeAnnotation } from 'jscodeshift';
 import { Collection } from 'jscodeshift/src/Collection';
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import { isDiagnosticWithLinePosition } from '../utils/type-guards';
 import { AnyAliasOptions, validateAnyAliasOptions } from '../utils/validateOptions';
@@ -11,7 +11,8 @@ const explicitAnyPlugin: Plugin<Options> = {
   name: 'explicit-any',
 
   run({ options, fileName, text, getLanguageService }) {
-    const semanticDiagnostics = getLanguageService().getSemanticDiagnostics(fileName);
+    const semanticDiagnostics =
+      getLanguageService().compilerObject.getSemanticDiagnostics(fileName);
     const diagnostics = semanticDiagnostics
       .filter(isDiagnosticWithLinePosition)
       .filter((d) => d.category === ts.DiagnosticCategory.Error);

--- a/packages/ts-migrate-plugins/src/plugins/hoist-class-statics.ts
+++ b/packages/ts-migrate-plugins/src/plugins/hoist-class-statics.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
 import {
@@ -16,7 +16,7 @@ const hoistClassStaticsPlugin: Plugin<Options> = {
   name: 'hoist-class-statics',
 
   run({ sourceFile, text, options }) {
-    return hoistStaticClassProperties(sourceFile, text, options);
+    return hoistStaticClassProperties(sourceFile.compilerNode, text, options);
   },
 
   validate: validateAnyAliasOptions,

--- a/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
+++ b/packages/ts-migrate-plugins/src/plugins/jsdoc.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import {
   AnyAliasOptions,
@@ -68,8 +68,8 @@ const jsDocPlugin: Plugin<Options> = {
   name: 'jsdoc',
 
   run({ sourceFile, options }) {
-    const updates = new UpdateTracker(sourceFile);
-    ts.transform(sourceFile, [jsDocTransformerFactory(updates, options)]);
+    const updates = new UpdateTracker(sourceFile.compilerNode);
+    ts.transform(sourceFile.compilerNode, [jsDocTransformerFactory(updates, options)]);
     return updates.apply();
   },
 

--- a/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
+++ b/packages/ts-migrate-plugins/src/plugins/member-accessibility.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-bitwise */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin, PluginOptionsError } from 'ts-migrate-server';
 
 import { Properties, validateOptions } from '../utils/validateOptions';
@@ -24,9 +24,11 @@ const memberAccessibilityPlugin: Plugin<Options> = {
   name: 'member-accessibility',
 
   run({ sourceFile, text, options }) {
-    const result = ts.transform(sourceFile, [memberAccessibilityTransformerFactory(options)]);
+    const result = ts.transform(sourceFile.compilerNode, [
+      memberAccessibilityTransformerFactory(options),
+    ]);
     const newSourceFile = result.transformed[0];
-    if (newSourceFile === sourceFile) {
+    if (newSourceFile === sourceFile.compilerNode) {
       return text;
     }
     const printer = ts.createPrinter();

--- a/packages/ts-migrate-plugins/src/plugins/react-class-lifecycle-methods.ts
+++ b/packages/ts-migrate-plugins/src/plugins/react-class-lifecycle-methods.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import { getReactComponentHeritageType, isReactClassComponent } from './utils/react';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
@@ -14,8 +14,10 @@ const reactClassLifecycleMethodsPlugin: Plugin<Options> = {
   name: 'react-class-lifecycle-methods',
 
   run({ fileName, sourceFile, text, options }) {
+    const tsSourceFile = sourceFile.compilerNode;
+
     return /\.tsx$/.test(fileName)
-      ? annotateReactComponentLifecycleMethods(sourceFile, text, options.force)
+      ? annotateReactComponentLifecycleMethods(tsSourceFile, text, options.force)
       : undefined;
   },
 

--- a/packages/ts-migrate-plugins/src/plugins/strip-ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/strip-ts-ignore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
 

--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { Plugin } from 'ts-migrate-server';
 import { isDiagnosticWithLinePosition } from '../utils/type-guards';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
@@ -16,9 +16,9 @@ const tsIgnorePlugin: Plugin<Options> = {
 
   run({ getLanguageService, fileName, sourceFile, options }) {
     const diagnostics = getLanguageService()
-      .getSemanticDiagnostics(fileName)
+      .compilerObject.getSemanticDiagnostics(fileName)
       .filter(isDiagnosticWithLinePosition);
-    return getTextWithIgnores(sourceFile, diagnostics, options);
+    return getTextWithIgnores(sourceFile.compilerNode, diagnostics, options);
   },
 
   validate: createValidate(optionProperties),

--- a/packages/ts-migrate-plugins/src/plugins/utils/identifiers.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/identifiers.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 
 export type KnownDefinitionMap = { [key: string]: { pos: number; end: number } };
 

--- a/packages/ts-migrate-plugins/src/plugins/utils/imports.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/imports.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, no-restricted-syntax */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { SourceTextUpdate } from '../../utils/updateSourceText';
 import { getTextPreservingWhitespace } from './text';
 
@@ -155,6 +155,7 @@ export function updateImports(
             : []),
           ...namedToAdd.map((cur) =>
             ts.factory.createImportSpecifier(
+              false,
               undefined,
               ts.factory.createIdentifier(cur.namedImport),
             ),
@@ -185,6 +186,7 @@ export function updateImports(
           importDeclaration.modifiers,
           importClause,
           importDeclaration.moduleSpecifier,
+          undefined,
         );
         const text = getTextPreservingWhitespace(importDeclaration, upImpDec, sourceFile);
         updates.push({
@@ -226,6 +228,7 @@ export function updateImports(
           ? ts.factory.createNamedImports(
               namedToAdd.map((cur) =>
                 ts.factory.createImportSpecifier(
+                  false,
                   undefined,
                   ts.factory.createIdentifier(cur.namedImport),
                 ),

--- a/packages/ts-migrate-plugins/src/plugins/utils/react-props.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/react-props.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define, no-restricted-syntax */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { getNumComponentsInSourceFile } from './react';
 import { collectIdentifiers } from './identifiers';
 import { PropTypesIdentifierMap } from '../react-props';

--- a/packages/ts-migrate-plugins/src/plugins/utils/react.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/react.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 
 function isReactClassComponentName(name: string): boolean {
   return name === 'Component' || name === 'PureComponent';

--- a/packages/ts-migrate-plugins/src/plugins/utils/text.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/text.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 
 export function getTextPreservingWhitespace(
   prevNode: ts.Node,

--- a/packages/ts-migrate-plugins/src/plugins/utils/token-pos.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/token-pos.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 
 /**
  * Returns the token whose text contains the position.

--- a/packages/ts-migrate-plugins/src/plugins/utils/update.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/update.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import updateSourceText, { SourceTextUpdate } from '../../utils/updateSourceText';
 
 /**

--- a/packages/ts-migrate-plugins/src/utils/type-guards.ts
+++ b/packages/ts-migrate-plugins/src/utils/type-guards.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 
 export function isDiagnosticWithLinePosition(
   diagnostic: ts.Diagnostic | ts.DiagnosticWithLocation | undefined,

--- a/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/explicit-any.test.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { mockPluginParams, mockDiagnostic, realPluginParams } from '../test-utils';
 import explicitAnyPlugin from '../../src/plugins/explicit-any';
 

--- a/packages/ts-migrate-plugins/tests/src/utils/identifiers.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/utils/identifiers.test.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { findKnownImports, findKnownVariables } from '../../../src/plugins/utils/identifiers';
 
 const fileName = 'file.tsx';

--- a/packages/ts-migrate-plugins/tests/src/utils/imports.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/utils/imports.test.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import { updateImports } from '../../../src/plugins/utils/imports';
 import updateSourceText from '../../../src/utils/updateSourceText';
 

--- a/packages/ts-migrate-plugins/tests/src/utils/token-pos.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/utils/token-pos.test.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { ts } from 'ts-morph';
 import getTokenAtPosition from '../../../src/plugins/utils/token-pos';
 
 describe('getTokenAtPos', () => {

--- a/packages/ts-migrate-server/package.json
+++ b/packages/ts-migrate-server/package.json
@@ -59,8 +59,8 @@
   "homepage": "https://github.com/airbnb/ts-migrate#readme",
   "license": "MIT",
   "dependencies": {
-    "@ts-morph/bootstrap": "^0.9.1",
     "pretty-ms": "^7.0.1",
+    "ts-morph": "^13.0.3",
     "updatable-log": "^0.2.0"
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",

--- a/packages/ts-migrate-server/types/index.ts
+++ b/packages/ts-migrate-server/types/index.ts
@@ -1,4 +1,4 @@
-import ts from 'typescript';
+import { LanguageService, SourceFile } from 'ts-morph';
 
 export type Nullable<T> = T | null | undefined;
 export interface PluginParams<TPluginOptions> {
@@ -6,8 +6,8 @@ export interface PluginParams<TPluginOptions> {
   fileName: string;
   rootDir: string;
   text: string;
-  sourceFile: ts.SourceFile;
-  getLanguageService: () => ts.LanguageService;
+  sourceFile: SourceFile;
+  getLanguageService: () => LanguageService;
 }
 
 export type PluginResult = string | void;


### PR DESCRIPTION
The short story behind is PR is idea of giving developers access to [ts-morph](https://ts-morph.com/) functionality (StourceFile, LanguageService wrappers) in plugins to modify the source code.

Currently, `ts-migrate` is using the [old version](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-server/package.json#L62) of [ts-morph bootstrap](https://github.com/dsherret/ts-morph/blob/latest/packages/ts-morph/CHANGELOG.md) to [create and compile a project](https://github.com/airbnb/ts-migrate/blob/master/packages/ts-migrate-server/src/migrate/index.ts#L35-L39).

First, this PR updates `ts-morph` dependency to the latest version, but this comes with drawback of using `ts` namespace from `ts-morph` ([it's expected](https://github.com/dsherret/ts-morph/blob/latest/packages/ts-morph/CHANGELOG.md#breaking-changes-3) to use `import { ts } from 'ts-morph'` instead of `import ts from 'typescript'`) because [typescript.d.ts](https://github.com/dsherret/ts-morph/blob/latest/packages/common/lib/typescript.d.ts) is bundled with ts-morph since version 10... and this brings us to stick to the latest supported typescript version [by ts-morph](https://github.com/dsherret/ts-morph/blob/latest/packages/common/package.json#L40) (currently 4.5.5 while 4.6 is already released).

And second, this PR is changing types of `PluginParams` interface properties `sourceFile` and `getLanguageService`  to ts-morph's ones:

```
import { LanguageService, SourceFile } from 'ts-morph';

export interface PluginParams<TPluginOptions> {
  ....
  sourceFile: SourceFile;
  getLanguageService: () => LanguageService;
}
```

This gives developer access to [ts-morph helper functions](https://ts-morph.com/manipulation/) to navigate and modify the source code ([example](https://github.com/airbnb/ts-migrate/pull/160/files#diff-4c8c37719adb3a48eae74e9de83bfbbf960bfdfe2b3602f6598e1d764a2b765a)), but breaks backward compatibility of ts-migrate at the same time - plugins need to be updated to use ts namespace from ts-morph and use `sourceFile.compilerNode` and `getLanguageService.compilerObject` to access to "original" SourceFile and LanguageService if needed.

It's probably better to change major version if this PR will be merged.
 