### PR TITLE
Add support of ts-morph's SourceFile and LanguageService to PluginsParams

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
             {
                 "arrowParens": "always",
                 "bracketSpacing": true,
-                "jsxBracketSameLine": false,
+                "bracketSameLine": false,
                 "printWidth": 100,
                 "proseWrap": "preserve",
                 "requirePragma": false,

--- a/packages/ts-migrate-example/src/example-plugin-ts-morph.ts
+++ b/packages/ts-migrate-example/src/example-plugin-ts-morph.ts
@@ -1,0 +1,30 @@
+import { Plugin } from 'ts-migrate-server';
+
+type Options = { shouldReplaceText?: boolean };
+
+const examplePluginTsMorph: Plugin<Options> = {
+  name: 'example-plugin-ts-morph',
+  async run({ tsMorphSourceFile }) {
+    // get all function declarations from the source file
+    const functionDeclarations = tsMorphSourceFile.getFunctions();
+
+    functionDeclarations.forEach((functionDeclaration) => {
+      const name = functionDeclaration.getName();
+
+      // add a jsDoc comment before the function
+      functionDeclaration.addJsDoc({
+        description: `This is the function ${name}`,
+      });
+    });
+
+    tsMorphSourceFile.formatText({
+      indentSize: 2,
+    });
+
+    tsMorphSourceFile.saveSync();
+
+    return tsMorphSourceFile.getFullText();
+  },
+};
+
+export default examplePluginTsMorph;

--- a/packages/ts-migrate-example/src/index.ts
+++ b/packages/ts-migrate-example/src/index.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import { migrate, MigrateConfig } from 'ts-migrate-server';
 
 import examplePluginTs from './example-plugin-ts';
+import examplePluginTsMorph from './example-plugin-ts-morph';
 import examplePluginText from './example-plugin-text';
 import examplePluginJscodeshift from './example-plugin-jscodeshift';
 
@@ -12,7 +13,8 @@ async function runMigration() {
   const config = new MigrateConfig()
     .addPlugin(examplePluginJscodeshift, {})
     .addPlugin(examplePluginTs, { shouldReplaceText: true })
-    .addPlugin(examplePluginText, {});
+    .addPlugin(examplePluginText, {})
+    .addPlugin(examplePluginTsMorph, {});
 
   const exitCode = await migrate({ rootDir: inputDir, config });
 

--- a/packages/ts-migrate-example/src/input/index.ts
+++ b/packages/ts-migrate-example/src/input/index.ts
@@ -1,3 +1,7 @@
 function mult(first, second) {
     return first * second;
 }
+
+function test() {
+  return 'test';
+}

--- a/packages/ts-migrate-example/src/input/tsconfig.json
+++ b/packages/ts-migrate-example/src/input/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "compilerOptions": {}
+}

--- a/packages/ts-migrate-server/package.json
+++ b/packages/ts-migrate-server/package.json
@@ -59,8 +59,8 @@
   "homepage": "https://github.com/airbnb/ts-migrate#readme",
   "license": "MIT",
   "dependencies": {
-    "@ts-morph/bootstrap": "^0.9.1",
     "pretty-ms": "^7.0.1",
+    "ts-morph": "^13.0.3",
     "updatable-log": "^0.2.0"
   },
   "gitHead": "7acf6067f15c9bb367cda9c47fcfb4203dcc54f3",

--- a/packages/ts-migrate-server/types/index.ts
+++ b/packages/ts-migrate-server/types/index.ts
@@ -1,4 +1,5 @@
 import ts from 'typescript';
+import { LanguageService, SourceFile } from 'ts-morph';
 
 export type Nullable<T> = T | null | undefined;
 export interface PluginParams<TPluginOptions> {
@@ -8,6 +9,8 @@ export interface PluginParams<TPluginOptions> {
   text: string;
   sourceFile: ts.SourceFile;
   getLanguageService: () => ts.LanguageService;
+  tsMorphSourceFile: SourceFile;
+  getTsMorphLanguageService: () => LanguageService;
 }
 
 export type PluginResult = string | void;


### PR DESCRIPTION
IN PROGRESS...

The main changes in this PR is adding ts-morhp`s SourceFile and LanguageService as PluginParams to allow dev to use them for code modifications. 

```
import { LanguageService, SourceFile } from 'ts-morph';

export interface PluginParams<TPluginOptions> {
  ....
  sourceFile: ts.SourceFile;
  getLanguageService: () => ts.LanguageService;
  tsMorphSourceFile: SourceFile;
  getTsMorphLanguageService: () => LanguageService;
}
```