### PR TITLE
add error message in logs

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/eslint-fix.ts
+++ b/packages/ts-migrate-plugins/src/plugins/eslint-fix.ts
@@ -26,7 +26,7 @@ const eslintFixPlugin: Plugin = {
       }
       return newText;
     } catch (e) {
-      console.error('Error occurred in eslint-fix plugin :(');
+      console.error('Error occurred in eslint-fix plugin: ', e.message);
       return text;
     }
   },


### PR DESCRIPTION
Hi, I was experiencing an issue with eslint-fix plugin but the error message was not being very descriptive since it only prints `'Error occurred in eslint-fix plugin :('` so I thought on maybe changing the message to include `e.message` in the eslint-fix catch. After some quick research, I noticed other people do the same so I thought about creating this PR.

there was a issue for it where people mentioned they had to do the same in order to get more information.

