### PR TITLE
Add ability to specify a custom message for the `ts-ignore` plugin

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -58,7 +58,7 @@ function getTextWithIgnores(
     const errorExpression = options.useTsIgnore ? 'ts-ignore' : `ts-expect-error`;
     const messageLimit = options.messageLimit ?? TS_IGNORE_MESSAGE_LIMIT;
     const messagePrefixInComment = options.messagePrefix ? ` ${options.messagePrefix}` : '';
-    const tsIgnoreCommentText = `@${errorExpression} ts-migrate(${code})${messagePrefixInComment}: ${
+    const tsIgnoreCommentText = `@${errorExpression} TS(${code})${messagePrefixInComment}: ${
       message.length > messageLimit
         ? `${message.slice(0, messageLimit)}... Remove this comment to see the full error message`
         : message

--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -8,11 +8,13 @@ import { createValidate, Properties } from '../utils/validateOptions';
 type Options = {
   useTsIgnore?: boolean;
   messageLimit?: number;
+  messagePrefix?: string;
 };
 
 const optionProperties: Properties = {
   useTsIgnore: { type: 'boolean' },
   messageLimit: { type: 'number' },
+  messagePrefix: { type: 'string' },
 };
 
 const tsIgnorePlugin: Plugin<Options> = {
@@ -55,7 +57,8 @@ function getTextWithIgnores(
     const message = messageLines[messageLines.length - 1];
     const errorExpression = options.useTsIgnore ? 'ts-ignore' : `ts-expect-error`;
     const messageLimit = options.messageLimit ?? TS_IGNORE_MESSAGE_LIMIT;
-    const tsIgnoreCommentText = `@${errorExpression} ts-migrate(${code}) FIXME: ${
+    const messagePrefixInComment = options.messagePrefix ? ` ${options.messagePrefix}` : '';
+    const tsIgnoreCommentText = `@${errorExpression}${messagePrefixInComment} ts-migrate(${code}) FIXME: ${
       message.length > messageLimit
         ? `${message.slice(0, messageLimit)}... Remove this comment to see the full error message`
         : message

--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -58,7 +58,7 @@ function getTextWithIgnores(
     const errorExpression = options.useTsIgnore ? 'ts-ignore' : `ts-expect-error`;
     const messageLimit = options.messageLimit ?? TS_IGNORE_MESSAGE_LIMIT;
     const messagePrefixInComment = options.messagePrefix ? ` ${options.messagePrefix}` : '';
-    const tsIgnoreCommentText = `@${errorExpression}${messagePrefixInComment} ts-migrate(${code}) FIXME: ${
+    const tsIgnoreCommentText = `@${errorExpression} ts-migrate(${code})${messagePrefixInComment}: ${
       message.length > messageLimit
         ? `${message.slice(0, messageLimit)}... Remove this comment to see the full error message`
         : message

--- a/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
+++ b/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ts-ignore plugin adds ignore comment 1`] = `
-"// @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+"// @ts-expect-error TS(123) FIXME: diagnostic message
 comsole.log('Hello');"
 `;
 
@@ -11,7 +11,7 @@ exports[`ts-ignore plugin adds ignore comment in jsx 1`] = `
 function Foo() {
   return (
     <div>
-      {/* @ts-expect-error ts-migrate(123) FIXME: diagnostic message */}
+      {/* @ts-expect-error TS(123) FIXME: diagnostic message */}
       <DoesNotExist />
     </div>
   );
@@ -27,7 +27,7 @@ exports[`ts-ignore plugin adds ignore comment in jsx with Fragment 1`] = `
 function Foo() {
   return (
     <>
-      {/* @ts-expect-error ts-migrate(123) FIXME: diagnostic message */}
+      {/* @ts-expect-error TS(123) FIXME: diagnostic message */}
       <DoesNotExist />
     </>
   );
@@ -38,12 +38,12 @@ export default Foo;
 `;
 
 exports[`ts-ignore plugin adds ignore comment with ts-ignore 1`] = `
-"// @ts-ignore ts-migrate(123) FIXME: diagnostic message
+"// @ts-ignore TS(123) FIXME: diagnostic message
 comsole.log('Hello');"
 `;
 
 exports[`ts-ignore plugin custom comment 1`] = `
-"// @ts-expect-error ts-migrate(123) custom message prefix: diagnostic message
+"// @ts-expect-error TS(123) custom message prefix: diagnostic message
 comsole.log('Hello');"
 `;
 
@@ -60,7 +60,7 @@ exports[`ts-ignore plugin does not add ignore comment for webpackChunkName 1`] =
 exports[`ts-ignore plugin handles error within ternary jsx expression 1`] = `
 "function Foo() {
   return someBoolean
-    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+    ? // @ts-expect-error TS(123) FIXME: diagnostic message
       <ComponentA />
     : <ComponentB />;
 }
@@ -70,7 +70,7 @@ exports[`ts-ignore plugin handles error within ternary jsx expression 1`] = `
 exports[`ts-ignore plugin handles error within ternary property access 1`] = `
 "function Foo() {
   return someBoolean
-    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+    ? // @ts-expect-error TS(123) FIXME: diagnostic message
       this.props.doesNotExist
     : <SomeComponent />;
 }
@@ -81,7 +81,7 @@ exports[`ts-ignore plugin handles error within ternary when false 1`] = `
 "function foo() {
   return something
     ? other
-    : // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+    : // @ts-expect-error TS(123) FIXME: diagnostic message
       doesNotExist;
 }
 "
@@ -90,7 +90,7 @@ exports[`ts-ignore plugin handles error within ternary when false 1`] = `
 exports[`ts-ignore plugin handles error within ternary when true 1`] = `
 "function foo() {
   return something
-    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+    ? // @ts-expect-error TS(123) FIXME: diagnostic message
       doesNotExist
     : other;
 }
@@ -101,7 +101,7 @@ exports[`ts-ignore plugin handles multiline ternary 1`] = `
 "function Foo() {
   return someBoolean ? (
     <ComponentA
-      // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+      // @ts-expect-error TS(123) FIXME: diagnostic message
       doesNotExist=\\"fail\\"
     />
   ) : (
@@ -113,7 +113,7 @@ exports[`ts-ignore plugin handles multiline ternary 1`] = `
 
 exports[`ts-ignore plugin handles neighboring eslint disable comment 1`] = `
 "function foo() {
-  // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+  // @ts-expect-error TS(123) FIXME: diagnostic message
   // eslint-disable-next-line
   return doesNotExist;
 }
@@ -122,23 +122,23 @@ exports[`ts-ignore plugin handles neighboring eslint disable comment 1`] = `
 
 exports[`ts-ignore plugin handles single line ternary 1`] = `
 "function Foo() {
-  // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+  // @ts-expect-error TS(123) FIXME: diagnostic message
   return someBoolean ? <ComponentA /> : <ComponentB />;
 }
 "
 `;
 
 exports[`ts-ignore plugin truncates error message if too long 1`] = `
-"// @ts-expect-error ts-migrate(123) FIXME: This message is too long to print and should be tr... Remove this comment to see the full error message
+"// @ts-expect-error TS(123) FIXME: This message is too long to print and should be tr... Remove this comment to see the full error message
 comsole.log('Hello');"
 `;
 
 exports[`ts-ignore plugin use message limit option to avoid error message truncation 1`] = `
-"// @ts-expect-error ts-migrate(123) FIXME: This message is long, but should not be translated because of the messageLimit option value
+"// @ts-expect-error TS(123) FIXME: This message is long, but should not be translated because of the messageLimit option value
 comsole.log('Hello');"
 `;
 
 exports[`ts-ignore plugin use message limit option to truncate a error message 1`] = `
-"// @ts-expect-error ts-migrate(123) FIXME: This message is too long, and should be truncated because of the messageLim... Remove this comment to see the full error message
+"// @ts-expect-error TS(123) FIXME: This message is too long, and should be truncated because of the messageLim... Remove this comment to see the full error message
 comsole.log('Hello');"
 `;

--- a/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
+++ b/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
@@ -43,7 +43,7 @@ comsole.log('Hello');"
 `;
 
 exports[`ts-ignore plugin custom comment 1`] = `
-"// @ts-expect-error custom message prefix ts-migrate(123) FIXME: diagnostic message
+"// @ts-expect-error ts-migrate(123) custom message prefix: diagnostic message
 comsole.log('Hello');"
 `;
 

--- a/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
+++ b/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
@@ -42,6 +42,11 @@ exports[`ts-ignore plugin adds ignore comment with ts-ignore 1`] = `
 comsole.log('Hello');"
 `;
 
+exports[`ts-ignore plugin custom comment 1`] = `
+"// @ts-expect-error custom message prefix ts-migrate(123) FIXME: diagnostic message
+comsole.log('Hello');"
+`;
+
 exports[`ts-ignore plugin does not add ignore comment for webpackChunkName 1`] = `
 "const getComponent = normalizeLoader(() =>
   import(

--- a/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
+++ b/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
@@ -134,6 +134,6 @@ comsole.log('Hello');"
 `;
 
 exports[`ts-ignore plugin use message limit option to truncate a error message 1`] = `
-"// @ts-expect-error ts-migrate(123) FIXME: This message is too long, and should be translated because of the messageLi... Remove this comment to see the full error message
+"// @ts-expect-error ts-migrate(123) FIXME: This message is too long, and should be truncated because of the messageLim... Remove this comment to see the full error message
 comsole.log('Hello');"
 `;

--- a/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
+++ b/packages/ts-migrate-plugins/tests/src/__snapshots__/ts-ignore.test.ts.snap
@@ -1,0 +1,139 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ts-ignore plugin adds ignore comment 1`] = `
+"// @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+comsole.log('Hello');"
+`;
+
+exports[`ts-ignore plugin adds ignore comment in jsx 1`] = `
+"import React from 'react';
+
+function Foo() {
+  return (
+    <div>
+      {/* @ts-expect-error ts-migrate(123) FIXME: diagnostic message */}
+      <DoesNotExist />
+    </div>
+  );
+}
+
+export default Foo;
+"
+`;
+
+exports[`ts-ignore plugin adds ignore comment in jsx with Fragment 1`] = `
+"import React from 'react';
+
+function Foo() {
+  return (
+    <>
+      {/* @ts-expect-error ts-migrate(123) FIXME: diagnostic message */}
+      <DoesNotExist />
+    </>
+  );
+}
+
+export default Foo;
+"
+`;
+
+exports[`ts-ignore plugin adds ignore comment with ts-ignore 1`] = `
+"// @ts-ignore ts-migrate(123) FIXME: diagnostic message
+comsole.log('Hello');"
+`;
+
+exports[`ts-ignore plugin does not add ignore comment for webpackChunkName 1`] = `
+"const getComponent = normalizeLoader(() =>
+  import(
+    /* webpackChunkName: \\"Component_async\\" */
+    './this_module_does_not_exist'
+  ),
+);
+"
+`;
+
+exports[`ts-ignore plugin handles error within ternary jsx expression 1`] = `
+"function Foo() {
+  return someBoolean
+    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+      <ComponentA />
+    : <ComponentB />;
+}
+"
+`;
+
+exports[`ts-ignore plugin handles error within ternary property access 1`] = `
+"function Foo() {
+  return someBoolean
+    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+      this.props.doesNotExist
+    : <SomeComponent />;
+}
+"
+`;
+
+exports[`ts-ignore plugin handles error within ternary when false 1`] = `
+"function foo() {
+  return something
+    ? other
+    : // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+      doesNotExist;
+}
+"
+`;
+
+exports[`ts-ignore plugin handles error within ternary when true 1`] = `
+"function foo() {
+  return something
+    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+      doesNotExist
+    : other;
+}
+"
+`;
+
+exports[`ts-ignore plugin handles multiline ternary 1`] = `
+"function Foo() {
+  return someBoolean ? (
+    <ComponentA
+      // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+      doesNotExist=\\"fail\\"
+    />
+  ) : (
+    <ComponentB />
+  );
+}
+"
+`;
+
+exports[`ts-ignore plugin handles neighboring eslint disable comment 1`] = `
+"function foo() {
+  // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+  // eslint-disable-next-line
+  return doesNotExist;
+}
+"
+`;
+
+exports[`ts-ignore plugin handles single line ternary 1`] = `
+"function Foo() {
+  // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
+  return someBoolean ? <ComponentA /> : <ComponentB />;
+}
+"
+`;
+
+exports[`ts-ignore plugin truncates error message if too long 1`] = `
+"// @ts-expect-error ts-migrate(123) FIXME: This message is too long to print and should be tr... Remove this comment to see the full error message
+comsole.log('Hello');"
+`;
+
+exports[`ts-ignore plugin use message limit option to avoid error message truncation 1`] = `
+"// @ts-expect-error ts-migrate(123) FIXME: This message is long, but should not be translated because of the messageLimit option value
+comsole.log('Hello');"
+`;
+
+exports[`ts-ignore plugin use message limit option to truncate a error message 1`] = `
+"// @ts-expect-error ts-migrate(123) FIXME: This message is too long, and should be translated because of the messageLi... Remove this comment to see the full error message
+comsole.log('Hello');"
+`;

--- a/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
@@ -13,6 +13,20 @@ describe('ts-ignore plugin', () => {
     expect(result).toMatchSnapshot();
   });
 
+  it('custom comment', async () => {
+    const text = "comsole.log('Hello');";
+    const result = await tsIgnorePlugin.run(
+      mockPluginParams({
+        text,
+        semanticDiagnostics: [mockDiagnostic(text, 'comsole')],
+        options: {
+          messagePrefix: 'custom message prefix',
+        },
+      }),
+    );
+    expect(result).toMatchSnapshot();
+  });
+
   it('adds ignore comment with ts-ignore', async () => {
     const text = "comsole.log('Hello');";
     const result = await tsIgnorePlugin.run(

--- a/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
@@ -10,8 +10,7 @@ describe('ts-ignore plugin', () => {
         semanticDiagnostics: [mockDiagnostic(text, 'comsole')],
       }),
     );
-    expect(result).toBe(`// @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-comsole.log('Hello');`);
+    expect(result).toMatchSnapshot();
   });
 
   it('adds ignore comment with ts-ignore', async () => {
@@ -23,8 +22,7 @@ comsole.log('Hello');`);
         options: { useTsIgnore: true },
       }),
     );
-    expect(result).toBe(`// @ts-ignore ts-migrate(123) FIXME: diagnostic message
-comsole.log('Hello');`);
+    expect(result).toMatchSnapshot();
   });
 
   it('adds ignore comment in jsx', async () => {
@@ -49,19 +47,7 @@ export default Foo;
       }),
     );
 
-    expect(result).toBe(`import React from 'react';
-
-function Foo() {
-  return (
-    <div>
-      {/* @ts-expect-error ts-migrate(123) FIXME: diagnostic message */}
-      <DoesNotExist />
-    </div>
-  );
-}
-
-export default Foo;
-`);
+    expect(result).toMatchSnapshot();
   });
   it('adds ignore comment in jsx with Fragment', async () => {
     const text = `import React from 'react';
@@ -85,19 +71,7 @@ export default Foo;
       }),
     );
 
-    expect(result).toBe(`import React from 'react';
-
-function Foo() {
-  return (
-    <>
-      {/* @ts-expect-error ts-migrate(123) FIXME: diagnostic message */}
-      <DoesNotExist />
-    </>
-  );
-}
-
-export default Foo;
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('truncates error message if too long', async () => {
@@ -112,9 +86,7 @@ export default Foo;
         ],
       }),
     );
-    expect(result)
-      .toBe(`// @ts-expect-error ts-migrate(123) FIXME: This message is too long to print and should be tr... Remove this comment to see the full error message
-comsole.log('Hello');`);
+    expect(result).toMatchSnapshot();
   });
 
   it('use message limit option to avoid error message truncation', async () => {
@@ -131,9 +103,7 @@ comsole.log('Hello');`);
         options: { messageLimit: 100 },
       }),
     );
-    expect(result)
-      .toBe(`// @ts-expect-error ts-migrate(123) FIXME: This message is long, but should not be translated because of the messageLimit option value
-comsole.log('Hello');`);
+    expect(result).toMatchSnapshot();
   });
 
   it('use message limit option to truncate a error message', async () => {
@@ -150,9 +120,7 @@ comsole.log('Hello');`);
         options: { messageLimit: 75 },
       }),
     );
-    expect(result)
-      .toBe(`// @ts-expect-error ts-migrate(123) FIXME: This message is too long, and should be translated because of the messageLi... Remove this comment to see the full error message
-comsole.log('Hello');`);
+    expect(result).toMatchSnapshot();
   });
 
   it('does not add ignore comment for webpackChunkName', async () => {
@@ -171,13 +139,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`const getComponent = normalizeLoader(() =>
-  import(
-    /* webpackChunkName: "Component_async" */
-    './this_module_does_not_exist'
-  ),
-);
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles error within ternary when true', async () => {
@@ -195,13 +157,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function foo() {
-  return something
-    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-      doesNotExist
-    : other;
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles error within ternary when false', async () => {
@@ -219,13 +175,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function foo() {
-  return something
-    ? other
-    : // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-      doesNotExist;
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles error within ternary jsx expression', async () => {
@@ -244,13 +194,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function Foo() {
-  return someBoolean
-    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-      <ComponentA />
-    : <ComponentB />;
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles error within ternary property access', async () => {
@@ -269,13 +213,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function Foo() {
-  return someBoolean
-    ? // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-      this.props.doesNotExist
-    : <SomeComponent />;
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles neighboring eslint disable comment', async () => {
@@ -292,12 +230,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function foo() {
-  // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-  // eslint-disable-next-line
-  return doesNotExist;
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles multiline ternary', async () => {
@@ -320,17 +253,7 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function Foo() {
-  return someBoolean ? (
-    <ComponentA
-      // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-      doesNotExist="fail"
-    />
-  ) : (
-    <ComponentB />
-  );
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 
   it('handles single line ternary', async () => {
@@ -347,10 +270,6 @@ comsole.log('Hello');`);
       }),
     );
 
-    expect(result).toBe(`function Foo() {
-  // @ts-expect-error ts-migrate(123) FIXME: diagnostic message
-  return someBoolean ? <ComponentA /> : <ComponentB />;
-}
-`);
+    expect(result).toMatchSnapshot();
   });
 });

--- a/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
@@ -114,7 +114,7 @@ export default Foo;
         semanticDiagnostics: [
           mockDiagnostic(text, 'comsole', {
             messageText:
-              'This message is too long, and should be translated because of the messageLimit option value',
+              'This message is too long, and should be truncated because of the messageLimit option value',
           }),
         ],
         options: { messageLimit: 75 },

--- a/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
@@ -8,6 +8,7 @@ describe('ts-ignore plugin', () => {
       mockPluginParams({
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'comsole')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
     expect(result).toMatchSnapshot();
@@ -33,7 +34,7 @@ describe('ts-ignore plugin', () => {
       mockPluginParams({
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'comsole')],
-        options: { useTsIgnore: true },
+        options: { useTsIgnore: true, messagePrefix: 'FIXME' },
       }),
     );
     expect(result).toMatchSnapshot();
@@ -58,6 +59,7 @@ export default Foo;
         fileName: 'Foo.tsx',
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'DoesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -82,6 +84,7 @@ export default Foo;
         fileName: 'Foo.tsx',
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'DoesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -98,6 +101,7 @@ export default Foo;
             messageText: 'This message is too long to print and should be truncated',
           }),
         ],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
     expect(result).toMatchSnapshot();
@@ -114,7 +118,7 @@ export default Foo;
               'This message is long, but should not be translated because of the messageLimit option value',
           }),
         ],
-        options: { messageLimit: 100 },
+        options: { messageLimit: 100, messagePrefix: 'FIXME' },
       }),
     );
     expect(result).toMatchSnapshot();
@@ -131,7 +135,7 @@ export default Foo;
               'This message is too long, and should be truncated because of the messageLimit option value',
           }),
         ],
-        options: { messageLimit: 75 },
+        options: { messageLimit: 75, messagePrefix: 'FIXME' },
       }),
     );
     expect(result).toMatchSnapshot();
@@ -150,6 +154,7 @@ export default Foo;
       mockPluginParams({
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'this_module_does_not_exist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -168,6 +173,7 @@ export default Foo;
       mockPluginParams({
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'doesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -186,6 +192,7 @@ export default Foo;
       mockPluginParams({
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'doesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -205,6 +212,7 @@ export default Foo;
         fileName: 'Foo.tsx',
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'ComponentA')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -224,6 +232,7 @@ export default Foo;
         fileName: 'Foo.tsx',
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'doesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -241,6 +250,7 @@ export default Foo;
       mockPluginParams({
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'doesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -264,6 +274,7 @@ export default Foo;
         fileName: 'Foo.tsx',
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'doesNotExist')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 
@@ -281,6 +292,7 @@ export default Foo;
         fileName: 'Foo.tsx',
         text,
         semanticDiagnostics: [mockDiagnostic(text, 'ComponentA')],
+        options: { messagePrefix: 'FIXME' },
       }),
     );
 

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -188,7 +188,17 @@ yargs
   .command(
     'reignore <folder>',
     'Re-run ts-ignore on a project',
-    (cmd) => cmd.positional('folder', { type: 'string' }).require(['folder']),
+    (cmd) =>
+      cmd
+        .option('p', {
+          alias: 'messagePrefix',
+          default: '',
+          type: 'string',
+          describe:
+            'A message to add to the ts-expect-error or ts-ignore comments that are inserted.',
+        })
+        .positional('folder', { type: 'string' })
+        .require(['folder']),
     async (args) => {
       const rootDir = path.resolve(process.cwd(), args.folder);
 
@@ -218,7 +228,9 @@ yargs
 
       const config = new MigrateConfig()
         .addPlugin(withChangeTracking(stripTSIgnorePlugin), {})
-        .addPlugin(withChangeTracking(tsIgnorePlugin), {})
+        .addPlugin(withChangeTracking(tsIgnorePlugin), {
+          messagePrefix: args.messagePrefix,
+        })
         .addPlugin(eslintFixChangedPlugin, {});
 
       const exitCode = await migrate({ rootDir, config });

--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -192,7 +192,7 @@ yargs
       cmd
         .option('p', {
           alias: 'messagePrefix',
-          default: '',
+          default: 'FIXME',
           type: 'string',
           describe:
             'A message to add to the ts-expect-error or ts-ignore comments that are inserted.',

--- a/packages/ts-migrate/tests/commands/migrate/migrate.test.ts
+++ b/packages/ts-migrate/tests/commands/migrate/migrate.test.ts
@@ -26,7 +26,7 @@ describe('migrate command', () => {
     copyDir(inputDir, rootDir);
     const config = new MigrateConfig()
       .addPlugin(explicitAnyPlugin, { anyAlias: '$TSFixMe' })
-      .addPlugin(tsIgnorePlugin, {})
+      .addPlugin(tsIgnorePlugin, { messagePrefix: 'FIXME' })
       .addPlugin(eslintFixPlugin, {});
 
     const exitCode = await migrate({ rootDir, config });

--- a/packages/ts-migrate/tests/commands/migrate/output/Foo.tsx
+++ b/packages/ts-migrate/tests/commands/migrate/output/Foo.tsx
@@ -6,7 +6,7 @@ type Props = {};
 function Foo(props: Props) {
   return (
     <div>
-      {/* @ts-expect-error ts-migrate(2304) FIXME: Cannot find name 'DoesNotExist'. */}
+      {/* @ts-expect-error TS(2304) FIXME: Cannot find name 'DoesNotExist'. */}
       <DoesNotExist />
     </div>
   );

--- a/packages/ts-migrate/tests/commands/migrate/output/file-1.ts
+++ b/packages/ts-migrate/tests/commands/migrate/output/file-1.ts
@@ -1,2 +1,2 @@
-// @ts-expect-error ts-migrate(2552) FIXME: Cannot find name 'comsole'. Did you mean 'console'... Remove this comment to see the full error message
+// @ts-expect-error TS(2552) FIXME: Cannot find name 'comsole'. Did you mean 'console'... Remove this comment to see the full error message
 comsole.log();


### PR DESCRIPTION
Related: #168.

This PR is likely easier to review commit-by-commit.

I moved the `ts-ignore` tests to be snapshot tests, since that makes it much easier to tweak the inserted message. I did the snapshot conversion as a separate commit, so you can verify the conversion itself didn't introduce any changes.

In addition to adding the ability to specify a custom message, I changed `ts-migrate(${code})` to `TS(${code})`. This is more compact, and makes it more obvious that it's a `TS-xxxx` type error code.