### PR TITLE
Fix issue with relative paths

### DIFF
--- a/packages/ts-migrate-server/src/migrate/index.ts
+++ b/packages/ts-migrate-server/src/migrate/index.ts
@@ -27,7 +27,7 @@ export default async function migrate({
   // Normalize sources to be an array of full paths.
   if (sources !== undefined) {
     sources = Array.isArray(sources) ? sources : [sources];
-    sources = sources.map((source) => path.join(rootDir, source));
+    sources = sources.map((source) => path.resolve(rootDir, source));
     log.info(`Ignoring sources from tsconfig.json, using the ones provided manually instead.`);
   }
 

--- a/packages/ts-migrate-server/tests/commands/migrate/migrate.test.ts
+++ b/packages/ts-migrate-server/tests/commands/migrate/migrate.test.ts
@@ -45,6 +45,68 @@ describe('migrate command', () => {
     expect(exitCode).toBe(0);
   });
 
+  describe('sources', () => {
+    it('Migrates project by using `sources`', async () => {
+      const inputDir = path.resolve(__dirname, 'input');
+      const outputDir = path.resolve(__dirname, 'output');
+      const configDir = path.resolve(__dirname, 'config');
+
+      copyDir(inputDir, rootDir);
+      copyDir(configDir, rootDir);
+
+      const config = new MigrateConfig().addPlugin(
+        {
+          name: 'test-plugin',
+          run({ text }) {
+            const newText = text.replace('test string', 'updated string');
+            return newText;
+          },
+        },
+        {},
+      );
+
+      const exitCode = await migrate({
+        rootDir,
+        config,
+        sources: 'index.ts',
+      });
+      fs.unlinkSync(path.resolve(rootDir, 'tsconfig.json'));
+      const [rootData, outputData] = getDirData(rootDir, outputDir);
+      expect(rootData).toEqual(outputData);
+      expect(exitCode).toBe(0);
+    });
+
+    it('Migrates project by using `sources` with an absolute path', async () => {
+      const inputDir = path.resolve(__dirname, 'input');
+      const outputDir = path.resolve(__dirname, 'output');
+      const configDir = path.resolve(__dirname, 'config');
+
+      copyDir(inputDir, rootDir);
+      copyDir(configDir, rootDir);
+
+      const config = new MigrateConfig().addPlugin(
+        {
+          name: 'test-plugin',
+          run({ text }) {
+            const newText = text.replace('test string', 'updated string');
+            return newText;
+          },
+        },
+        {},
+      );
+
+      const exitCode = await migrate({
+        rootDir,
+        config,
+        sources: path.resolve(rootDir, 'index.ts'),
+      });
+      fs.unlinkSync(path.resolve(rootDir, 'tsconfig.json'));
+      const [rootData, outputData] = getDirData(rootDir, outputDir);
+      expect(rootData).toEqual(outputData);
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it('Migrates project with two plugins', async () => {
     const inputDir = path.resolve(__dirname, 'input');
     const outputDir = path.resolve(__dirname, 'output_two');


### PR DESCRIPTION
Part of https://github.com/airbnb/ts-migrate/issues/168.

Previously, absolute paths passed to `sources` were handled incorrectly.