### PR TITLE
Allow --aliases to work also when individually running plugins

### DIFF
--- a/packages/ts-migrate/cli.ts
+++ b/packages/ts-migrate/cli.ts
@@ -124,6 +124,12 @@ yargs
       const { sources } = args;
       let config: MigrateConfig;
 
+      const airbnbAnyAlias = '$TSFixMe';
+      const airbnbAnyFunctionAlias = '$TSFixMeFunction';
+      // by default, we're not going to use any aliases in ts-migrate
+      const anyAlias = args.aliases === 'tsfixme' ? airbnbAnyAlias : undefined;
+      const anyFunctionAlias = args.aliases === 'tsfixme' ? airbnbAnyFunctionAlias : undefined;
+
       if (args.plugin) {
         const plugin = availablePlugins.find((cur) => cur.name === args.plugin);
         if (!plugin) {
@@ -136,14 +142,12 @@ yargs
           const typeMap = typeof args.typeMap === 'string' ? JSON.parse(args.typeMap) : undefined;
           config = new MigrateConfig().addPlugin(jsDocPlugin, { anyAlias, typeMap });
         } else {
-          config = new MigrateConfig().addPlugin(plugin, {});
+          config = new MigrateConfig().addPlugin(plugin, {
+            anyAlias,
+            anyFunctionAlias,
+          });
         }
       } else {
-        const airbnbAnyAlias = '$TSFixMe';
-        const airbnbAnyFunctionAlias = '$TSFixMeFunction';
-        // by default, we're not going to use any aliases in ts-migrate
-        const anyAlias = args.aliases === 'tsfixme' ? airbnbAnyAlias : undefined;
-        const anyFunctionAlias = args.aliases === 'tsfixme' ? airbnbAnyFunctionAlias : undefined;
         const useDefaultPropsHelper = args.useDefaultPropsHelper === 'true';
 
         const { defaultAccessibility, privateRegex, protectedRegex, publicRegex } = args;


### PR DESCRIPTION
As part of working around [a bug in the add-conversions plugin](https://github.com/airbnb/ts-migrate/issues/178) I'm running plugins separately and skipping over that one. I would still like to add `$TSFixMe` vs `any` in the code, and found that the `--aliases` argument is ignored unless you run either all plugins, or run just the JSDoc one.

This PR addresses that