### PR TITLE
Nested ExpressionStatements Issue #144

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
+++ b/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
@@ -158,7 +158,7 @@ const addConversionsTransformerFactory =
  * an if statement condition or other construct that can contain blocks.
  */
 function shouldReplace(origNode: ts.Node, node: ts.Node): boolean {
-  if (node.kind === ts.SyntaxKind.ExpressionStatement && ancestorIsExpressionStatement(origNode)) {
+  if (ancestorIsExpressionStatement(origNode)) {
     return false;
   }
 

--- a/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
+++ b/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
@@ -158,7 +158,7 @@ const addConversionsTransformerFactory =
  * an if statement condition or other construct that can contain blocks.
  */
 function shouldReplace(origNode: ts.Node, node: ts.Node): boolean {
-  if (node.kind == ts.SyntaxKind.ExpressionStatement && ancestorIsExpressionStatement(origNode)) {
+  if (node.kind === ts.SyntaxKind.ExpressionStatement && ancestorIsExpressionStatement(origNode)) {
     return false;
   }
 
@@ -179,12 +179,13 @@ function shouldReplace(origNode: ts.Node, node: ts.Node): boolean {
 }
 
 function ancestorIsExpressionStatement(origNode: ts.Node): boolean {
-  if (origNode.parent == undefined)
-  {
+  if (origNode.parent === undefined) {
     return false;
-  } else {
-    return origNode.parent.kind == ts.SyntaxKind.ExpressionStatement || ancestorIsExpressionStatement(origNode.parent)
   }
+  return (
+    origNode.parent.kind === ts.SyntaxKind.ExpressionStatement ||
+    ancestorIsExpressionStatement(origNode.parent)
+  );
 }
 
 function isStatement(node: ts.Node): node is ts.Statement {

--- a/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
+++ b/packages/ts-migrate-plugins/src/plugins/add-conversions.ts
@@ -81,7 +81,7 @@ const addConversionsTransformerFactory =
         node = factory.createAsExpression(node as ts.Expression, anyType);
       }
 
-      if (shouldReplace(node)) {
+      if (shouldReplace(origNode, node)) {
         replaceNode(origNode, node);
         return origNode;
       }
@@ -157,7 +157,11 @@ const addConversionsTransformerFactory =
  * There is still some risk of losing whitespace if the expression is contained within
  * an if statement condition or other construct that can contain blocks.
  */
-function shouldReplace(node: ts.Node): boolean {
+function shouldReplace(origNode: ts.Node, node: ts.Node): boolean {
+  if (node.kind == ts.SyntaxKind.ExpressionStatement && ancestorIsExpressionStatement(origNode)) {
+    return false;
+  }
+
   if (isStatement(node)) {
     return true;
   }
@@ -171,6 +175,15 @@ function shouldReplace(node: ts.Node): boolean {
       return true;
     default:
       return false;
+  }
+}
+
+function ancestorIsExpressionStatement(origNode: ts.Node): boolean {
+  if (origNode.parent == undefined)
+  {
+    return false;
+  } else {
+    return origNode.parent.kind == ts.SyntaxKind.ExpressionStatement || ancestorIsExpressionStatement(origNode.parent)
   }
 }
 

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -113,4 +113,11 @@ class PublishEvent {
 }
 `);
   });
+
+  it('handles anonymous functions that require as any without duplicating lines (issue #144)', async () => {
+    const text = `var window = { onResetData: function () { this.clearNextPush = function () { this.setState({ history: [] }); }; } };`;
+    const result = addConversionsPlugin.run(await realPluginParams({ text }));
+
+    expect(result).toBe(`var window = { onResetData: function () { (this as any).clearNextPush = function () { (this as any).setState({ history: [] }); }; } };`);
+  });
 });

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -114,12 +114,21 @@ class PublishEvent {
 `);
   });
 
-  it('handles anonymous functions that require as any without duplicating lines (issue #144)', async () => {
+  it('Nested Expression Statements (issue #144) Part 1: Expression Statement -> Expression Statement', async () => {
     const text = `var window = { onResetData: function () { this.clearNextPush = function () { this.setState({ history: [] }); }; } };`;
     const result = addConversionsPlugin.run(await realPluginParams({ text }));
 
     expect(result).toBe(
       `var window = { onResetData: function () { (this as any).clearNextPush = function () { (this as any).setState({ history: [] }); }; } };`,
+    );
+  });
+
+  it('Nested Expression Statements (issue #144) Part 2: Expression Statement -> If Statement -> Expression Statement', async () => {
+    const text = `const window = { onResetData() { this.clearNextPush = function () {\n    if (this.setState) {\n    this.setState({ history: [] });\n} }; } };`;
+    const result = addConversionsPlugin.run(await realPluginParams({ text }));
+
+    expect(result).toBe(
+      `const window = { onResetData() { (this as any).clearNextPush = function () {\n    if ((this as any).setState) {\n        (this as any).setState({ history: [] });\n    }\n}; } };`,
     );
   });
 });

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -118,6 +118,8 @@ class PublishEvent {
     const text = `var window = { onResetData: function () { this.clearNextPush = function () { this.setState({ history: [] }); }; } };`;
     const result = addConversionsPlugin.run(await realPluginParams({ text }));
 
-    expect(result).toBe(`var window = { onResetData: function () { (this as any).clearNextPush = function () { (this as any).setState({ history: [] }); }; } };`);
+    expect(result).toBe(
+      `var window = { onResetData: function () { (this as any).clearNextPush = function () { (this as any).setState({ history: [] }); }; } };`,
+    );
   });
 });


### PR DESCRIPTION
As discussed in #144 ts-migrate will duplicate code when the add-conversion plug in is ran. This fix addresses the situation when there are nested expression statements that need to have `as any` applied. Previously nested expression statements would generate  multiple overlapping updates, which results in duplicate lines of code one with the conversions changes and one without. 

There a number of things I don't know which I would appreciate feedback/help with:
- Are there other combinations of syntax that generate similar issues?
- How can I test these changes on an existing code base? I don't know much about node. 
- All the original tests still pass, is there additional testing that should be doing?

