### PR TITLE
Fix mangling dollar signs followed by numbers (dollar amounts)

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/utils/update.ts
+++ b/packages/ts-migrate-plugins/src/plugins/utils/update.ts
@@ -69,7 +69,7 @@ class UpdateTracker {
       );
       const text = oldNode
         .getFullText(this.sourceFile)
-        .replace(/^(\s*)[^]*?(\s*)$/, `$1${printedNextNode}$2`);
+        .replace(/^(\s*)[^]*?(\s*)$/, (_match, p1, p2) => `${p1}${printedNextNode}${p2}`);
       this.updates.push({
         kind: 'replace',
         index: oldNode.pos,

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -131,4 +131,31 @@ class PublishEvent {
       `const window = { onResetData() { (this as any).clearNextPush = function () {\n    if ((this as any).setState) {\n        (this as any).setState({ history: [] });\n    }\n}; } };`,
     );
   });
+
+  it('handles dollar amounts', async () => {
+    const text = `\
+import customUtils from "custom-utils";
+
+it("tests", () => {
+  thing.fn("arg");
+
+  const thing = {
+    value: "$1"
+  };
+});
+`;
+    const result = addConversionsPlugin.run(await realPluginParams({ text }));
+
+    expect(result).toBe(`\
+import customUtils from "custom-utils";
+
+it("tests", () => {
+    (thing as any).fn("arg");
+
+    const thing = {
+        value: "$1"
+    };
+});
+`);
+  });
 });

--- a/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/add-conversions.test.ts
@@ -151,7 +151,6 @@ import customUtils from "custom-utils";
 
 it("tests", () => {
     (thing as any).fn("arg");
-
     const thing = {
         value: "$1"
     };


### PR DESCRIPTION
When the `add-conversions` plugin runs, it replaces some text with regex using capture groups `$1` and `$2`. If the text it's replacing itself contains a dollar amount such as `$100` that will also have the first 2 characters replaced and treated like a capture group.

This pull request proposes fixing this issue by using a replacer function: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_function_as_the_replacement

Possibly related to https://github.com/airbnb/ts-migrate/issues/162.

I added a minimal failing test case. I'm not certain exactly why this triggers it (presumably produces an AST that hits an uncommon code path) but included it to show a case where this problem happens.