### PR TITLE
inJsxText closing element bug

### DIFF
--- a/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
+++ b/packages/ts-migrate-plugins/src/plugins/ts-ignore.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-use-before-define, @typescript-eslint/no-use-before-define */
-import ts from 'typescript';
+import ts, { isJsxFragment } from 'typescript';
 import { Plugin } from 'ts-migrate-server';
 import { isDiagnosticWithLinePosition } from '../utils/type-guards';
 import updateSourceText, { SourceTextUpdate } from '../utils/updateSourceText';
@@ -166,7 +166,8 @@ function inJsxText(sourceFile: ts.SourceFile, pos: number) {
       const isJsxTextChild = node.children.some(
         (child) => ts.isJsxText(child) && child.pos <= pos && pos < child.end,
       );
-      if (isJsxTextChild) {
+      const isClosingElement = !isJsxFragment(node) && node.closingElement.pos === pos;
+      if (isJsxTextChild || isClosingElement) {
         return true;
       }
     }

--- a/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
+++ b/packages/ts-migrate-plugins/tests/src/ts-ignore.test.ts
@@ -409,4 +409,26 @@ export default Foo;
       "
     `);
   });
+
+  it('add comment to closing tag in tsx file', async () => {
+    const text = `<div>
+  <span>text</span>
+</div>
+`;
+    const result = await tsIgnorePlugin.run(
+      mockPluginParams({
+        fileName: 'Foo.tsx',
+        text,
+        semanticDiagnostics: [mockDiagnostic(text, '/div')],
+        options: { messagePrefix: 'FIXME' },
+      }),
+    );
+    expect(result).toMatchInlineSnapshot(`
+"<div>
+  <span>text</span>
+{/* @ts-expect-error TS(123) FIXME: diagnostic message */}
+</div>
+"
+`);
+  });
 });


### PR DESCRIPTION
- inJsxText would always return false if the position it was given was a closing tag. This caused ts-ignore to not properly comment @ts-expect-error messages when they were added to tsx files.
- Issue #150